### PR TITLE
feat: 認証フォームのフィードバック機能を改善

### DIFF
--- a/src/app/(auth)/login/page.module.scss
+++ b/src/app/(auth)/login/page.module.scss
@@ -63,6 +63,38 @@
   }
 }
 
+// Server Actionからのフィードバックメッセージ表示エリア
+.message {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 60px;
+  margin-bottom: 1.5rem;
+  padding: 1rem;
+  border-radius: 8px;
+  text-align: center;
+  transition: all 0.2s;
+
+  // デフォルトでは非表示（領域だけ確保）
+  background-color: transparent;
+  border: 1px solid transparent;
+  color: transparent;
+}
+
+// 成功メッセージのスタイリング
+.success {
+  background-color: lighten($color-primary, 35%);
+  border-color: lighten($color-primary, 20%);
+  color: darken($color-primary, 20%);
+}
+
+// エラーメッセージのスタイリング
+.error {
+  background-color: lighten($color-error, 38%);
+  border-color: $color-error;
+  color: $color-error;
+}
+
 // スクリーンリーダー専用テキスト（視覚的に隠すが読み上げ可能）
 .srOnly {
   position: absolute;

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,48 +1,37 @@
 'use client';
 
-import { useState } from 'react';
+import { useActionState } from 'react';
 
 import Button from '@/components/ui/Button/Button';
 import { login } from '@/lib/actions';
 
 import styles from './page.module.scss';
 
+const initialState = {
+  message: '',
+  isError: false,
+  email: '',
+};
+
 /**
  * ユーザーログインページ
  * メールアドレスとパスワードでの認証を行う
  */
 const LoginPage = () => {
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-
-    const formData = new FormData();
-    formData.append('email', email);
-    formData.append('password', password);
-
-    try {
-      await login(formData);
-    } catch (error) {
-      // Next.jsのリダイレクトエラーは再スローして正常な動作を継続
-      if (error instanceof Error && error.message.includes('NEXT_REDIRECT')) {
-        throw error;
-      }
-
-      // ユーザー向けエラーメッセージを表示
-      if (error instanceof Error) {
-        alert('エラー：' + error.message);
-      } else {
-        alert('予期せぬエラーが発生しました。');
-      }
-    }
-  };
+  const [state, formAction] = useActionState(login, initialState);
 
   return (
     <main className={styles.container}>
       <h1 className={styles.title}>ログイン</h1>
-      <form className={styles.form} onSubmit={handleSubmit}>
+
+      <p
+        className={`${styles.message} ${state.message ? (state.isError ? styles.error : styles.success) : ''}`}
+        aria-live="polite"
+      >
+        {state.message || <>&nbsp;</>}
+      </p>
+
+      <form className={styles.form} action={formAction}>
         <fieldset className={styles.fieldset}>
           <legend className={styles.srOnly}>ログイン情報</legend>
           <div className={styles.formGroup}>
@@ -55,11 +44,9 @@ const LoginPage = () => {
               name="email"
               id="email"
               required
-              value={email}
               autoComplete="username"
-              onChange={(e) => {
-                setEmail(e.target.value);
-              }}
+              key={state.message}
+              defaultValue={state.email}
             />
           </div>
 
@@ -73,11 +60,7 @@ const LoginPage = () => {
               name="password"
               id="password"
               required
-              value={password}
               autoComplete="current-password"
-              onChange={(e) => {
-                setPassword(e.target.value);
-              }}
             />
           </div>
 

--- a/src/app/(auth)/signup/page.module.scss
+++ b/src/app/(auth)/signup/page.module.scss
@@ -63,6 +63,37 @@
   }
 }
 
+// Server Actionからのフィードバックメッセージ表示エリア
+.message {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 60px;
+  margin-bottom: 1.5rem;
+  padding: 1rem;
+  border-radius: 8px;
+  text-align: center;
+  transition: all 0.2s;
+
+  // デフォルトでは非表示（領域だけ確保）
+  background-color: transparent;
+  border: 1px solid transparent;
+  color: transparent;
+}
+
+// 成功メッセージのスタイリング
+.success {
+  background-color: lighten($color-primary, 35%);
+  border-color: lighten($color-primary, 20%);
+  color: darken($color-primary, 20%);
+}
+
+// エラーメッセージのスタイリング
+.error {
+  background-color: lighten($color-error, 38%);
+  border-color: $color-error;
+  color: $color-error;
+}
 // スクリーンリーダー専用テキスト（視覚的に隠すが読み上げ可能）
 .srOnly {
   position: absolute;

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -1,56 +1,39 @@
 'use client';
 
-import React, { useState } from 'react';
+import { useActionState } from 'react';
 
 import Button from '@/components/ui/Button/Button';
 import { signup } from '@/lib/actions';
 
 import styles from './page.module.scss';
 
+// Server Actionと連携するための初期状態
+const initialState = {
+  message: '',
+  isError: false,
+  email: '',
+};
+
 /**
  * ユーザー新規登録ページ
  * メールアドレス・パスワードでアカウントを作成し、確認メールを送信
  */
 const SignUpPage = () => {
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [passwordConfirm, setPasswordConfirm] = useState('');
-
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-
-    // パスワード確認のバリデーション
-    if (password !== passwordConfirm) {
-      alert('パスワードが一致しません');
-      return;
-    }
-
-    const formData = new FormData();
-    formData.append('email', email);
-    formData.append('password', password);
-
-    try {
-      await signup(formData);
-
-      // 成功時はフォームをリセットしてユーザーに通知
-      setEmail('');
-      setPassword('');
-      setPasswordConfirm('');
-      alert('確認メールを送信しました。メールボックスを確認してください。');
-    } catch (error) {
-      // エラーハンドリング
-      if (error instanceof Error) {
-        alert('エラー：' + error.message);
-      } else {
-        alert('予期せぬエラーが発生しました。');
-      }
-    }
-  };
+  // useActionStateフックでフォームの状態(state)とアクション(formAction)を管理
+  const [state, formAction] = useActionState(signup, initialState);
 
   return (
     <main className={styles.container}>
       <h1 className={styles.title}>アカウント登録</h1>
-      <form className={styles.form} onSubmit={handleSubmit}>
+
+      <p
+        className={`${styles.message} ${state.message ? (state.isError ? styles.error : styles.success) : ''}`}
+        aria-live="polite"
+      >
+        {state.message || <>&nbsp;</>}
+      </p>
+
+      <form className={styles.form} action={formAction}>
         <fieldset className={styles.fieldset}>
           <legend className={styles.srOnly}>アカウント情報</legend>
 
@@ -64,12 +47,9 @@ const SignUpPage = () => {
               name="email"
               id="email"
               required
-              aria-describedby="email-error"
               autoComplete="username"
-              value={email}
-              onChange={(e) => {
-                setEmail(e.target.value);
-              }}
+              key={state.message}
+              defaultValue={state.email}
             />
           </div>
 
@@ -83,12 +63,7 @@ const SignUpPage = () => {
               name="password"
               id="password"
               required
-              aria-describedby="password-error"
               autoComplete="new-password"
-              value={password}
-              onChange={(e) => {
-                setPassword(e.target.value);
-              }}
             />
           </div>
 
@@ -102,12 +77,7 @@ const SignUpPage = () => {
               name="password_confirm"
               id="password_confirm"
               required
-              aria-describedby="password-confirm-error"
               autoComplete="new-password"
-              value={passwordConfirm}
-              onChange={(e) => {
-                setPasswordConfirm(e.target.value);
-              }}
             />
           </div>
 

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -4,21 +4,38 @@ import { redirect } from 'next/navigation';
 
 import { createSupabaseServerClient } from './supabase/server';
 
+type FormState = {
+  message: string;
+  isError: boolean;
+  email?: string;
+};
+
 /**
  * ユーザー新規登録
  * メール認証後にログイン画面にリダイレクト
  */
-export const signup = async (formData: FormData) => {
+export const signup = async (prevstate: FormState, formData: FormData): Promise<FormState> => {
   const email = formData.get('email') as string;
   const password = formData.get('password') as string;
+  const passwordConfirm = formData.get('password_confirm') as string;
 
+  // パスワード確認のバリデーション
+  if (password !== passwordConfirm) {
+    return { message: 'パスワードが一致しません。', isError: true, email: email };
+  }
+
+  // 必須項目のバリデーション
   if (!email || !password) {
-    throw new Error('メールアドレスとパスワードを入力してください。');
+    return {
+      message: 'メールアドレスとパスワードを入力してください。',
+      isError: true,
+      email: email,
+    };
   }
 
   const supabase = await createSupabaseServerClient();
 
-  const { error } = await supabase.auth.signUp({
+  const { data, error } = await supabase.auth.signUp({
     email,
     password,
     options: {
@@ -28,8 +45,26 @@ export const signup = async (formData: FormData) => {
 
   if (error) {
     console.error(error);
-    throw new Error('アカウント登録に失敗しました。');
+    return {
+      message: 'アカウント登録に失敗しました。',
+      isError: true,
+      email: email,
+    };
   }
+
+  // 既存アカウントのチェック
+  if (data.user && data.user.identities?.length === 0) {
+    return {
+      message: 'このメールアドレスは既に使用されています。',
+      isError: true,
+      email: email,
+    };
+  }
+
+  return {
+    message: '確認メールを送信しました。メールボックスを確認してください。',
+    isError: false,
+  };
 };
 
 /**

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -71,9 +71,18 @@ export const signup = async (prevstate: FormState, formData: FormData): Promise<
  * ユーザーログイン
  * 成功時はホームページにリダイレクト
  */
-export const login = async (formData: FormData) => {
+export const login = async (prevState: FormState, formData: FormData): Promise<FormState> => {
   const email = formData.get('email') as string;
   const password = formData.get('password') as string;
+
+  // 必須項目のバリデーション
+  if (!email || !password) {
+    return {
+      message: 'メールアドレスとパスワードを入力してください。',
+      isError: true,
+      email: email,
+    };
+  }
 
   const supabase = await createSupabaseServerClient();
 
@@ -84,7 +93,11 @@ export const login = async (formData: FormData) => {
 
   if (error) {
     console.error(error);
-    throw new Error('メールアドレスまたはパスワードが間違っています。');
+    return {
+      message: 'メールアドレスまたはパスワードが間違っています。',
+      isError: true,
+      email: email,
+    };
   }
 
   redirect('/');


### PR DESCRIPTION
### 概要
サインアップページとログインページのフォームフィードバック機能を改善し、アラート表示を廃止しました。

### 実装したこと
- [x] **`useActionState`の導入**
  - `SignUpPage`と`LoginPage`をリファクタリングし、モダンなフォーム状態管理を実装
- [x] **UI/UXの改善**
  - `alert()`を廃止し、画面上に成功・エラーメッセージを表示
  - エラー時にフォームの入力内容（メールアドレス）を保持
- [x] **サーバーサイドバリデーションの強化**
  - `signup`アクションに、登録済みメールアドレスの重複チェックを追加