### PR TITLE
feat: 投稿削除時に確認モーダルを表示

### DIFF
--- a/src/components/features/posts/PostCard/PostCard.tsx
+++ b/src/components/features/posts/PostCard/PostCard.tsx
@@ -1,6 +1,9 @@
 'use client';
 
+import { useState } from 'react';
+
 import Button from '@/components/ui/Button/Button';
+import ConfirmModal from '@/components/ui/ConfirmModal/ConfirmModal';
 import { deletePost } from '@/lib/actions';
 import { type PostWithProfile } from '@/types';
 
@@ -19,6 +22,15 @@ const PostCard = ({ post, userId }: PostCardProps) => {
   // 現在のユーザーが投稿者かどうかを判定
   const isOwnPost = userId && userId === post.user_id;
 
+  // モーダルの開閉状態の判定
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  // 投稿の削除処理
+  const handleDeleteConfirm = async () => {
+    await deletePost(post.id);
+    setIsModalOpen(false);
+  };
+
   return (
     <li>
       <article className={styles.card}>
@@ -32,14 +44,30 @@ const PostCard = ({ post, userId }: PostCardProps) => {
         {/* 投稿者本人のみ削除ボタンを表示 */}
         {isOwnPost && (
           <div className={styles.actions}>
-            <form action={deletePost.bind(null, post.id)}>
-              <Button type="submit" variant="secondary" size="small">
-                削除
-              </Button>
-            </form>
+            <Button
+              type="button"
+              variant="secondary"
+              size="small"
+              onClick={() => {
+                setIsModalOpen(true);
+              }}
+            >
+              削除
+            </Button>
           </div>
         )}
       </article>
+
+      <ConfirmModal
+        isOpen={isModalOpen}
+        onClose={() => {
+          setIsModalOpen(false);
+        }}
+        onConfirm={handleDeleteConfirm}
+        title="投稿を削除"
+      >
+        <p>この操作は取り消せません。本当にこの投稿を削除しますか？</p>
+      </ConfirmModal>
     </li>
   );
 };

--- a/src/components/ui/Button/Button.module.scss
+++ b/src/components/ui/Button/Button.module.scss
@@ -54,3 +54,12 @@
     background-color: darken($color-gray-light, 5%);
   }
 }
+
+.danger {
+  background-color: $color-error;
+  color: $color-white; // 文字色も指定
+
+  &:hover:not(:disabled) {
+    background-color: darken($color-error, 10%);
+  }
+}

--- a/src/components/ui/Button/Button.tsx
+++ b/src/components/ui/Button/Button.tsx
@@ -2,7 +2,7 @@ import { type ComponentPropsWithoutRef, type FC, type ReactNode } from 'react';
 
 import styles from './Button.module.scss';
 
-type ButtonVariant = 'primary' | 'secondary';
+type ButtonVariant = 'primary' | 'secondary' | 'danger';
 type ButtonSize = 'medium' | 'small';
 
 type ButtonProps = {

--- a/src/components/ui/ConfirmModal/ConfirmModal.module.scss
+++ b/src/components/ui/ConfirmModal/ConfirmModal.module.scss
@@ -1,0 +1,27 @@
+@use 'styles/variables' as *;
+
+// モーダル内のコンテンツエリア
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+// モーダルのタイトル
+.title {
+  font-size: 1.5rem;
+  margin: 0;
+}
+
+// 確認メッセージの本文
+.message {
+  color: $color-gray-dark;
+}
+
+// アクションボタン（OK/キャンセル）のコンテナ
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+  margin-top: 1rem;
+}

--- a/src/components/ui/ConfirmModal/ConfirmModal.tsx
+++ b/src/components/ui/ConfirmModal/ConfirmModal.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { type FC, type ReactNode } from 'react';
+
+import Button from '@/components/ui/Button/Button';
+import Modal from '@/components/ui/Modal/Modal';
+
+import styles from './ConfirmModal.module.scss';
+
+type ConfirmModalProps = {
+  /** モーダルが開いているかどうか */
+  isOpen: boolean;
+  /** モーダルが閉じる時に呼ばれる関数 */
+  onClose: () => void;
+  /** OKボタンが押された時に呼ばれる関数 */
+  onConfirm: () => void;
+  /** ダイアログのタイトル */
+  title: string;
+  /** 確認メッセージなどの本文 */
+  children: ReactNode;
+};
+
+/**
+ * 汎用的な<Modal>を使い、「OK」「キャンセル」の選択肢を持つ確認ダイアログを構築するコンポーネント
+ */
+const ConfirmModal: FC<ConfirmModalProps> = ({ isOpen, onClose, onConfirm, title, children }) => {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <div className={styles.content}>
+        <h3 className={styles.title}>{title}</h3>
+        <div className={styles.message}>{children}</div>
+        <div className={styles.actions}>
+          <Button type="button" variant="secondary" onClick={onClose}>
+            キャンセル
+          </Button>
+          <Button type="button" variant="danger" onClick={onConfirm}>
+            OK
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default ConfirmModal;

--- a/src/components/ui/Modal/Modal.module.scss
+++ b/src/components/ui/Modal/Modal.module.scss
@@ -1,0 +1,33 @@
+@use 'styles/variables' as *;
+
+// ダイアログ本体
+.dialog {
+  background-color: $color-white;
+  margin: auto;
+  padding: 2rem;
+  border-radius: 8px;
+  max-width: 500px;
+  width: 90%;
+  box-shadow: 0 4px 12px rgb(0 0 0 / 0.15);
+  border: none;
+
+  &[open] {
+    animation: fadeIn 0.3s ease-out;
+  }
+
+  // 背景のオーバーレイ
+  &::backdrop {
+    background-color: rgb(0 0 0 / 0.5);
+    animation: fadeIn 0.3s ease-out;
+  }
+}
+
+// フェードインのアニメーション
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}

--- a/src/components/ui/Modal/Modal.tsx
+++ b/src/components/ui/Modal/Modal.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { type FC, type ReactNode, useEffect, useRef } from 'react';
+
+import styles from './Modal.module.scss';
+
+type ModalProps = {
+  children: ReactNode;
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+/**
+ * HTMLの<dialog>要素をラップした、汎用的なモーダルコンポーネント。
+ * 親から渡される`isOpen`の状態に応じて、`.showModal()`と`.close()`を副作用として実行する。
+ */
+const Modal: FC<ModalProps> = ({ children, isOpen, onClose }) => {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (dialog) {
+      if (isOpen) {
+        dialog.showModal();
+      } else {
+        dialog.close();
+      }
+    }
+  }, [isOpen]);
+
+  return (
+    <dialog ref={dialogRef} onClose={onClose} className={styles.dialog}>
+      {children}
+    </dialog>
+  );
+};
+
+export default Modal;


### PR DESCRIPTION
### 概要
ユーザーが誤って投稿を削除することを防ぐため、削除操作の前に確認モーダルを表示する機能を追加しました。

### 実装したこと
- [x] **投稿削除時の確認機能**
  - 削除ボタンクリック時に確認モーダルを表示し、ユーザーの最終意思を確認
- [x] **汎用的なモーダルコンポーネントの作成**
  - HTMLの`<dialog>`要素をラップした`<Modal>`コンポーネントを実装
  - 確認ダイアログ専用の`<ConfirmModal>`を実装し、ロジックを再利用可能に
- [x] **`<Button>`コンポーネントの強化**
  - 危険な操作を示す`'danger'`バリアントを新しく追加し、UIの一貫性を向上