### PR TITLE
refactor: PostFormのロジックをカスタムフックに分離

### DIFF
--- a/src/components/features/posts/PostForm/PostForm.tsx
+++ b/src/components/features/posts/PostForm/PostForm.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import Link from 'next/link';
-import { useActionState, useEffect, useState } from 'react';
+import { useActionState, useState } from 'react';
 
 import Button from '@/components/ui/Button/Button';
+import { useProfileStatus } from '@/hooks/useProfileStatus';
 import { createPost } from '@/lib/actions';
-import { createSupabaseBrowserClient } from '@/lib/supabase/client';
 
 import styles from './PostForm.module.scss';
 
@@ -23,33 +23,13 @@ const PostForm = () => {
 
   // フォームの展開状態を管理するstate
   const [isExpanded, setIsExpanded] = useState(false);
-  // プロフィール設定完了状態を管理するstate
-  const [isProfileComplete, setIsProfileComplete] = useState(false);
 
   // マウント時にプロフィール設定状況をチェック
-  useEffect(() => {
-    const checkProfile = async () => {
-      const supabase = createSupabaseBrowserClient();
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
+  const { isProfileComplete, isLoading } = useProfileStatus();
 
-      if (user) {
-        const { data: profile } = await supabase
-          .from('profiles')
-          .select('user_name, current_gobi')
-          .eq('id', user.id)
-          .single();
-
-        // ユーザー名とカスタム語尾の両方が設定されているかチェック
-        if (profile?.user_name && profile.current_gobi) {
-          setIsProfileComplete(true);
-        }
-      }
-    };
-
-    void checkProfile();
-  }, []);
+  if (isLoading) {
+    return null;
+  }
 
   // 折りたたみ時は展開ボタンのみ表示
   if (!isExpanded) {

--- a/src/hooks/useProfileStatus.ts
+++ b/src/hooks/useProfileStatus.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+
+import { createSupabaseBrowserClient } from '@/lib/supabase/client';
+
+/**
+ * 現在のユーザーのプロフィール設定状況をチェックするカスタムフック
+ * @returns {{isProfileComplete: boolean, isLoading: boolean}} プロフィールの完了状態とローディング状態
+ */
+export const useProfileStatus = () => {
+  const [isProfileComplete, setIsProfileComplete] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // コンポーネントのマウント時に一度だけ実行
+  useEffect(() => {
+    const checkProfile = async () => {
+      const supabase = createSupabaseBrowserClient();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      if (user) {
+        const { data: profile } = await supabase
+          .from('profiles')
+          .select('user_name, current_gobi')
+          .eq('id', user.id)
+          .single();
+
+        // プロフィール完了の条件：ユーザー名と語尾の両方が設定されていること
+        if (profile?.user_name && profile.current_gobi) {
+          setIsProfileComplete(true);
+        }
+      }
+      setIsLoading(false);
+    };
+
+    void checkProfile();
+  }, []);
+
+  return { isProfileComplete, isLoading };
+};


### PR DESCRIPTION
### 概要

面談での「UIとロジックの分離」というフィードバックを元に、`PostForm`コンポーネントのリファクタリングを行いました。

### 実装したこと

✅ **カスタムフックの作成**
- プロフィール設定状況をチェックするロジックを、再利用可能なカスタムフック `useProfileStatus`として `src/hooks` に切り出しました。
- データ取得中のUIのちらつきを防ぐため、`isLoading`状態も併せて返すようにしています。

✅ **PostFormコンポーネントの修正**
- 既存の`useEffect`ロジックを削除し、作成した`useProfileStatus`フックを呼び出すように変更しました。