### PR TITLE
feat: 認証フォームをRHFとzodで刷新

### DIFF
--- a/src/app/(auth)/login/page.module.scss
+++ b/src/app/(auth)/login/page.module.scss
@@ -82,36 +82,10 @@
   }
 }
 
-// Server Actionからのフィードバックメッセージ表示エリア
-.message {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: 60px;
-  margin-bottom: 1.5rem;
-  padding: 1rem;
-  border-radius: 8px;
-  text-align: center;
-  transition: all 0.2s;
-
-  // デフォルトでは非表示（領域だけ確保）
-  background-color: transparent;
-  border: 1px solid transparent;
-  color: transparent;
-}
-
-// 成功メッセージのスタイリング
-.success {
-  background-color: lighten($color-primary, 35%);
-  border-color: lighten($color-primary, 20%);
-  color: darken($color-primary, 20%);
-}
-
-// エラーメッセージのスタイリング
-.error {
-  background-color: lighten($color-error, 38%);
-  border-color: $color-error;
+// エラーメッセージのスタイル
+.errorMessage {
   color: $color-error;
+  margin-top: 0.25rem;
 }
 
 // スクリーンリーダー専用テキスト（視覚的に隠すが読み上げ可能）

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,38 +1,29 @@
 'use client';
 
 import Link from 'next/link';
-import { useActionState } from 'react';
 
 import Button from '@/components/ui/Button/Button';
-import { login } from '@/lib/actions';
+import { useLoginForm } from '@/hooks/useLoginForm';
 
 import styles from './page.module.scss';
-
-const initialState = {
-  message: '',
-  isError: false,
-  email: '',
-};
 
 /**
  * ユーザーログインページ
  * メールアドレスとパスワードでの認証を行う
  */
 const LoginPage = () => {
-  const [state, formAction] = useActionState(login, initialState);
+  const { form, onSubmit } = useLoginForm();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = form;
 
   return (
     <main className={styles.container}>
       <h1 className={styles.title}>ログイン</h1>
 
-      <p
-        className={`${styles.message} ${state.message ? (state.isError ? styles.error : styles.success) : ''}`}
-        aria-live="polite"
-      >
-        {state.message || <>&nbsp;</>}
-      </p>
-
-      <form className={styles.form} action={formAction}>
+      <form className={styles.form} onSubmit={handleSubmit(onSubmit)}>
         <fieldset className={styles.fieldset}>
           <legend className={styles.srOnly}>ログイン情報</legend>
           <div className={styles.formGroup}>
@@ -42,13 +33,11 @@ const LoginPage = () => {
             <input
               type="email"
               className={styles.input}
-              name="email"
               id="email"
-              required
               autoComplete="username"
-              key={state.message}
-              defaultValue={state.email}
+              {...register('email')}
             />
+            {errors.email && <p className={styles.errorMessage}>{errors.email.message}</p>}
           </div>
 
           <div className={styles.formGroup}>
@@ -58,15 +47,15 @@ const LoginPage = () => {
             <input
               type="password"
               className={styles.input}
-              name="password"
               id="password"
-              required
               autoComplete="current-password"
+              {...register('password')}
             />
+            {errors.password && <p className={styles.errorMessage}>{errors.password.message}</p>}
           </div>
 
-          <Button type="submit" variant="primary">
-            ログイン
+          <Button type="submit" variant="primary" disabled={isSubmitting}>
+            {isSubmitting ? 'ログイン中...' : 'ログイン'}
           </Button>
         </fieldset>
       </form>

--- a/src/app/(auth)/signup/page.module.scss
+++ b/src/app/(auth)/signup/page.module.scss
@@ -82,37 +82,12 @@
   }
 }
 
-// Server Actionからのフィードバックメッセージ表示エリア
-.message {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: 60px;
-  margin-bottom: 1.5rem;
-  padding: 1rem;
-  border-radius: 8px;
-  text-align: center;
-  transition: all 0.2s;
-
-  // デフォルトでは非表示（領域だけ確保）
-  background-color: transparent;
-  border: 1px solid transparent;
-  color: transparent;
-}
-
-// 成功メッセージのスタイリング
-.success {
-  background-color: lighten($color-primary, 35%);
-  border-color: lighten($color-primary, 20%);
-  color: darken($color-primary, 20%);
-}
-
-// エラーメッセージのスタイリング
-.error {
-  background-color: lighten($color-error, 38%);
-  border-color: $color-error;
+// エラーメッセージのスタイル
+.errorMessage {
   color: $color-error;
+  margin-top: 0.25rem;
 }
+
 // スクリーンリーダー専用テキスト（視覚的に隠すが読み上げ可能）
 .srOnly {
   position: absolute;

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -1,40 +1,29 @@
 'use client';
 
 import Link from 'next/link';
-import { useActionState } from 'react';
 
 import Button from '@/components/ui/Button/Button';
-import { signup } from '@/lib/actions';
+import { useSignUpForm } from '@/hooks/useSignUpForm';
 
 import styles from './page.module.scss';
-
-// Server Actionと連携するための初期状態
-const initialState = {
-  message: '',
-  isError: false,
-  email: '',
-};
 
 /**
  * ユーザー新規登録ページ
  * メールアドレス・パスワードでアカウントを作成し、確認メールを送信
  */
 const SignUpPage = () => {
-  // useActionStateフックでフォームの状態(state)とアクション(formAction)を管理
-  const [state, formAction] = useActionState(signup, initialState);
+  const { form, onSubmit } = useSignUpForm();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = form;
 
   return (
     <main className={styles.container}>
       <h1 className={styles.title}>アカウント登録</h1>
 
-      <p
-        className={`${styles.message} ${state.message ? (state.isError ? styles.error : styles.success) : ''}`}
-        aria-live="polite"
-      >
-        {state.message || <>&nbsp;</>}
-      </p>
-
-      <form className={styles.form} action={formAction}>
+      <form className={styles.form} onSubmit={handleSubmit(onSubmit)}>
         <fieldset className={styles.fieldset}>
           <legend className={styles.srOnly}>アカウント情報</legend>
 
@@ -45,13 +34,11 @@ const SignUpPage = () => {
             <input
               type="email"
               className={styles.input}
-              name="email"
               id="email"
-              required
               autoComplete="username"
-              key={state.message}
-              defaultValue={state.email}
+              {...register('email')}
             />
+            {errors.email && <p className={styles.errorMessage}>{errors.email.message}</p>}
           </div>
 
           <div className={styles.formGroup}>
@@ -61,11 +48,11 @@ const SignUpPage = () => {
             <input
               type="password"
               className={styles.input}
-              name="password"
               id="password"
-              required
               autoComplete="new-password"
+              {...register('password')}
             />
+            {errors.password && <p className={styles.errorMessage}>{errors.password.message}</p>}
           </div>
 
           <div className={styles.formGroup}>
@@ -75,15 +62,17 @@ const SignUpPage = () => {
             <input
               type="password"
               className={styles.input}
-              name="password_confirm"
               id="password_confirm"
-              required
               autoComplete="new-password"
+              {...register('password_confirm')}
             />
+            {errors.password_confirm && (
+              <p className={styles.errorMessage}>{errors.password_confirm.message}</p>
+            )}
           </div>
 
-          <Button type="submit" variant="primary">
-            登録する
+          <Button type="submit" variant="primary" disabled={isSubmitting}>
+            {isSubmitting ? '登録中...' : '登録する'}
           </Button>
         </fieldset>
       </form>

--- a/src/hooks/useLoginForm.ts
+++ b/src/hooks/useLoginForm.ts
@@ -1,0 +1,37 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { SubmitHandler, useForm } from 'react-hook-form';
+import { toast } from 'react-hot-toast';
+import { z } from 'zod';
+
+import { login } from '@/lib/actions';
+import { loginSchema } from '@/lib/schema';
+
+type LoginFormData = z.infer<typeof loginSchema>;
+
+/**
+ * ログインフォームに関するロジックをすべてカプセル化したカスタムフック
+ */
+export const useLoginForm = () => {
+  const form = useForm<LoginFormData>({
+    resolver: zodResolver(loginSchema),
+    mode: 'onBlur',
+    defaultValues: {
+      email: '',
+      password: '',
+    },
+  });
+
+  const onSubmit: SubmitHandler<LoginFormData> = async (data) => {
+    try {
+      await login(data);
+    } catch (error) {
+      if (error instanceof Error) {
+        toast.error(error.message);
+      } else {
+        toast.error('ログインに失敗しました。');
+      }
+    }
+  };
+
+  return { form, onSubmit };
+};

--- a/src/hooks/useSignUpForm.ts
+++ b/src/hooks/useSignUpForm.ts
@@ -1,0 +1,40 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { SubmitHandler, useForm } from 'react-hook-form';
+import { toast } from 'react-hot-toast';
+import { z } from 'zod';
+
+import { signup } from '@/lib/actions';
+import { signupSchema } from '@/lib/schema';
+
+type SignUpFormData = z.infer<typeof signupSchema>;
+
+/**
+ * 新規登録フォームに関するロジックをすべてカプセル化したカスタムフック
+ */
+export const useSignUpForm = () => {
+  const form = useForm<SignUpFormData>({
+    resolver: zodResolver(signupSchema),
+    mode: 'onBlur',
+    defaultValues: {
+      email: '',
+      password: '',
+      password_confirm: '',
+    },
+  });
+
+  const onSubmit: SubmitHandler<SignUpFormData> = async (data) => {
+    try {
+      await signup(data);
+      toast.success('確認メールを送信しました。メールボックスを確認してください。');
+      form.reset();
+    } catch (error) {
+      if (error instanceof Error) {
+        toast.error(error.message);
+      } else {
+        toast.error('アカウント登録に失敗しました。');
+      }
+    }
+  };
+
+  return { form, onSubmit };
+};

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -3,45 +3,27 @@ import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 import { z } from 'zod';
 
-import { loginSchema } from './schema';
+import { signupSchema, loginSchema } from './schema';
 import { createSupabaseServerClient } from './supabase/server';
 
-type FormState = {
-  message: string;
-  isError: boolean;
-  email?: string;
-};
-
 type LoginFormData = z.infer<typeof loginSchema>;
+type SignupFormData = z.infer<typeof signupSchema>;
 
 /**
  * ユーザー新規登録
  * メール認証後にログイン画面にリダイレクト
  */
-export const signup = async (prevstate: FormState, formData: FormData): Promise<FormState> => {
-  const email = formData.get('email') as string;
-  const password = formData.get('password') as string;
-  const passwordConfirm = formData.get('password_confirm') as string;
-
-  // パスワード確認のバリデーション
-  if (password !== passwordConfirm) {
-    return { message: 'パスワードが一致しません。', isError: true, email: email };
-  }
-
-  // 必須項目のバリデーション
-  if (!email || !password) {
-    return {
-      message: 'メールアドレスとパスワードを入力してください。',
-      isError: true,
-      email: email,
-    };
+export const signup = async (data: SignupFormData) => {
+  const result = signupSchema.safeParse(data);
+  if (!result.success) {
+    throw new Error('入力データが無効です。');
   }
 
   const supabase = await createSupabaseServerClient();
 
-  const { data, error } = await supabase.auth.signUp({
-    email,
-    password,
+  const { data: signUpData, error } = await supabase.auth.signUp({
+    email: data.email,
+    password: data.password,
     options: {
       emailRedirectTo: '/login',
     },
@@ -49,26 +31,13 @@ export const signup = async (prevstate: FormState, formData: FormData): Promise<
 
   if (error) {
     console.error(error);
-    return {
-      message: 'アカウント登録に失敗しました。',
-      isError: true,
-      email: email,
-    };
+    throw new Error('アカウント登録に失敗しました。');
   }
 
   // 既存アカウントのチェック
-  if (data.user && data.user.identities?.length === 0) {
-    return {
-      message: 'このメールアドレスは既に使用されています。',
-      isError: true,
-      email: email,
-    };
+  if (signUpData.user && signUpData.user.identities?.length === 0) {
+    throw new Error('このメールアドレスは既に使用されています。');
   }
-
-  return {
-    message: '確認メールを送信しました。メールボックスを確認してください。',
-    isError: false,
-  };
 };
 
 /**

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -24,3 +24,20 @@ export const loginSchema = z.object({
     .pipe(z.email('正しいメールアドレスを入力してください。')),
   password: z.string().min(1, 'パスワードを入力してください。'),
 });
+
+/**
+ * 新規登録フォーム用のバリデーションスキーマ
+ */
+export const signupSchema = z
+  .object({
+    email: z
+      .string()
+      .min(1, 'メールアドレスを入力してください。')
+      .pipe(z.email('正しいメールアドレスを入力してください。')),
+    password: z.string().min(8, 'パスワードは8文字以上で入力してください。'),
+    password_confirm: z.string().min(1, '確認用パスワードを入力してください。'),
+  })
+  .refine((data) => data.password === data.password_confirm, {
+    message: 'パスワードが一致しません。',
+    path: ['password_confirm'],
+  });

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -9,9 +9,18 @@ export const createPostSchema = (gobi: string) => {
   return z.object({
     content: z
       .string()
-      .min(1, { message: '投稿内容を入力してください。' })
-      .refine((value) => value.includes(gobi), {
-        message: `投稿に語尾「${gobi}」を含めてください。`,
-      }),
+      .min(1, '投稿内容を入力してください。')
+      .refine((value) => value.includes(gobi), `投稿に語尾「${gobi}」を含めてください。`),
   });
 };
+
+/**
+ * ログインフォーム用のバリデーションスキーマ
+ */
+export const loginSchema = z.object({
+  email: z
+    .string()
+    .min(1, 'メールアドレスを入力してください。')
+    .pipe(z.email('正しいメールアドレスを入力してください。')),
+  password: z.string().min(1, 'パスワードを入力してください。'),
+});


### PR DESCRIPTION
### 概要

ログインページと新規登録ページの両方を、`react-hook-form`と`zod`を使ったモダンな実装に刷新しました。
これにより、リアルタイムのフィールド別バリデーションや、`react-hot-toast`によるサーバーからのフィードバックが可能になり、ユーザー体験が大幅に向上します。

### 実装したこと

✅ **バリデーションスキーマの作成**
- `loginSchema`と`signupSchema`を`zod`で定義しました。
- 新規登録フォームでは、`.refine`を用いてパスワードの一致確認をスキーマレベルで実装しました。

✅ **Server Actionの改修**
- `login`および`signup`アクションを、型付きオブジェクトを引数に取り、失敗時にエラーを`throw`する形式にリファクタリングしました。
- バリデーションロジックをZodに集約したことで、アクション内のコードがよりシンプルになりました。

✅ **カスタムフックによるロジックの分離**
- `useLoginForm`と`useSignUpForm`というフォーム専用のカスタムフックを作成し、フォーム関連のロジックをすべてカプセル化しました。
- `try...catch`構文と`toast`を使い、サーバーからのエラーを適切にハンドリングします。

✅ **UIコンポーネントの刷新**
- `LoginPage`と`SignUpPage`から`useActionState`を削除し、作成したカスタムフックを呼び出すだけの、シンプルなUIコンポーネントにリファクタリングしました。