### PR TITLE
feat: Buttonコンポーネントをポリモーフィック化し適用

### DIFF
--- a/src/components/features/posts/PostForm/PostForm.tsx
+++ b/src/components/features/posts/PostForm/PostForm.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import Link from 'next/link';
 import { useState } from 'react';
 
 import Button from '@/components/ui/Button/Button';
@@ -47,9 +46,9 @@ const PostForm = () => {
     return (
       <div className={styles.notice}>
         <p>投稿するには、プロフィール設定でユーザー名とカスタム語尾を設定する必要があります。</p>
-        <Link href="/account/profile">
-          <Button variant="primary">設定ページへ</Button>
-        </Link>
+        <Button href="/account/profile" variant="primary">
+          設定ページへ
+        </Button>
       </div>
     );
   }

--- a/src/components/layout/Header/Header.module.scss
+++ b/src/components/layout/Header/Header.module.scss
@@ -28,21 +28,3 @@
   align-items: center;
   gap: 1.5rem; // ナビゲーション要素間の余白
 }
-
-// ナビゲーションリンク（ボタン風スタイル）
-.navLink {
-  display: inline-block;
-  background-color: $color-gray-light;
-  color: $color-gray-dark;
-  border: 1px solid $color-gray-medium;
-  border-radius: 9999px; // 完全な角丸（ピル型）
-  padding: 0.5rem 1.5rem;
-  font-weight: bold;
-  text-decoration: none;
-  transition: background-color 0.2s; // ホバー時のスムーズな色変化
-
-  &:hover {
-    background-color: darken($color-gray-light, 5%); // ホバー時に少し暗く
-    color: $color-gray-dark;
-  }
-}

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -26,9 +26,9 @@ const Header = async () => {
       {/* ログイン済みユーザー向けナビゲーション */}
       {session && (
         <nav className={styles.nav}>
-          <Link href="/account/profile" className={styles.navLink}>
+          <Button href="/account/profile" variant="secondary">
             プロフィール設定
-          </Link>
+          </Button>
           <form action={logout}>
             <Button type="submit" variant="secondary">
               ログアウト

--- a/src/components/ui/Button/Button.tsx
+++ b/src/components/ui/Button/Button.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import { type ComponentPropsWithoutRef, type FC, type ReactNode } from 'react';
 
 import styles from './Button.module.scss';
@@ -5,19 +6,53 @@ import styles from './Button.module.scss';
 type ButtonVariant = 'primary' | 'secondary' | 'danger';
 type ButtonSize = 'medium' | 'small';
 
-type ButtonProps = {
+/** ボタンとリンクで共通する、見た目に関する基本的なProps */
+type BaseProps = {
   children: ReactNode;
   variant?: ButtonVariant;
   size?: ButtonSize;
-} & ComponentPropsWithoutRef<'button'>;
+};
+
+/** <button>として扱われる場合のPropsの設計図 */
+type ButtonAsButton = BaseProps &
+  ComponentPropsWithoutRef<'button'> & {
+    href?: never;
+  };
+
+/** <Link>として扱われる場合のPropsの設計図 */
+type ButtonAsLink = BaseProps &
+  Omit<ComponentPropsWithoutRef<typeof Link>, 'type'> & {
+    href: string;
+  };
+
+/** 上記2つのどちらかの型に一致することを表現するUnion型 */
+type ButtonProps = ButtonAsButton | ButtonAsLink;
+
+/** ButtonPropsがどちらの型かを判別する型ガード関数 */
+function isLink(props: ButtonProps): props is ButtonAsLink {
+  return 'href' in props;
+}
 
 /**
- * 再利用可能なボタンコンポーネント
+ * 再利用可能なポリモーフィックボタンコンポーネント
+ * hrefプロパティの有無で<button>と<Link>を切り替える
  * primary/secondaryのバリアント、medium/smallのサイズをサポート
  */
-const Button: FC<ButtonProps> = ({ children, variant = 'primary', size = 'medium', ...rest }) => {
+const Button: FC<ButtonProps> = (props) => {
+  const classNames = `${styles.button} ${styles[props.variant ?? 'primary']} ${styles[props.size ?? 'medium']}`;
+
+  if (isLink(props)) {
+    const { children, ...rest } = props;
+    return (
+      <Link {...rest} className={classNames}>
+        {children}
+      </Link>
+    );
+  }
+
+  const { children, ...rest } = props;
   return (
-    <button className={`${styles.button} ${styles[variant]} ${styles[size]}`} {...rest}>
+    <button {...rest} className={classNames}>
       {children}
     </button>
   );


### PR DESCRIPTION
## 概要

`Button`コンポーネントをポリモーフィック化し、リンクとしても機能するように拡張しました。
これにより、アプリケーション全体のUIコンポーネントの再利用性とデザインの一貫性が大幅に向上します。

### 実装したこと

- **Buttonコンポーネントのポリモーフィック化**
  - 「判別可能なUnion型」と「型ガード関数」を用いて、`href`プロパティの有無に応じて`<button>`と`<Link>`を出し分けるように実装しました。
- **既存コンポーネントへの適用**
  - `Header`コンポーネント内の「プロフィール設定」リンクを、新しい`Button`コンポーネントに置き換えました。
  - `PostForm`コンポーネント内の「設定ページへ」リンクを、新しい`Button`コンポーネントに置き換えました。
- **不要なCSSの削除**
  - コンポーネントの置き換えに伴い、不要になった`Header.module.scss`内の`.navLink`スタイルを削除しました。