### PR TITLE
refactor: React Contextを導入しプロップドリルを解消

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -1,5 +1,6 @@
 import PostForm from '@/components/features/posts/PostForm/PostForm';
 import PostList from '@/components/features/posts/PostList/PostList';
+import { TimelineContext } from '@/contexts/TimelineContext';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 
 import styles from './page.module.scss';
@@ -62,19 +63,21 @@ const HomePage = async () => {
     }
   }
 
+  const TimelineContextValue = {
+    userId: user?.id ?? null,
+    likedPostIds,
+    followingUserIds,
+  };
+
   return (
     <>
       <header className={styles.header}>
         <h2 className={styles.title}>タイムライン</h2>
         <PostForm />
       </header>
-
-      <PostList
-        posts={posts}
-        userId={user?.id ?? null}
-        likedPostIds={likedPostIds}
-        followingUserIds={followingUserIds}
-      />
+      <TimelineContext value={TimelineContextValue}>
+        <PostList posts={posts} />
+      </TimelineContext>
     </>
   );
 };

--- a/src/components/features/posts/PostCard/PostCard.tsx
+++ b/src/components/features/posts/PostCard/PostCard.tsx
@@ -6,6 +6,7 @@ import { FaHeart, FaRegHeart } from 'react-icons/fa';
 
 import Button from '@/components/ui/Button/Button';
 import ConfirmModal from '@/components/ui/ConfirmModal/ConfirmModal';
+import { useTimeline } from '@/contexts/TimelineContext';
 import { deletePost, followUser, likePost, unfollowUser, unlikePost } from '@/lib/actions';
 import { type PostWithProfile } from '@/types';
 
@@ -13,16 +14,16 @@ import styles from './PostCard.module.scss';
 
 type PostCardProps = {
   post: PostWithProfile;
-  userId: string | null;
-  likedPostIds: Set<number>;
-  followingUserIds: Set<string>;
 };
 
 /**
  * 個別の投稿を表示するカードコンポーネント
  * 投稿者本人のみ削除ボタンを表示
  */
-const PostCard = ({ post, userId, likedPostIds, followingUserIds }: PostCardProps) => {
+const PostCard = ({ post }: PostCardProps) => {
+  // Contextからデータを取得
+  const { userId, likedPostIds, followingUserIds } = useTimeline();
+
   // 現在のユーザーが投稿者かどうかを判定
   const isOwnPost = userId && userId === post.user_id;
 

--- a/src/components/features/posts/PostList/PostList.tsx
+++ b/src/components/features/posts/PostList/PostList.tsx
@@ -5,16 +5,13 @@ import styles from './PostList.module.scss';
 
 type PostListProps = {
   posts: PostWithProfile[] | null;
-  userId: string | null;
-  likedPostIds: Set<number>;
-  followingUserIds: Set<string>;
 };
 
 /**
  * 投稿一覧を表示するコンポーネント
  * 投稿がない場合は適切なメッセージを表示
  */
-const PostList = ({ posts, userId, likedPostIds, followingUserIds }: PostListProps) => {
+const PostList = ({ posts }: PostListProps) => {
   // 投稿データがない場合の表示
   if (!posts || posts.length === 0) {
     return <p>まだ投稿がありません</p>;
@@ -23,13 +20,7 @@ const PostList = ({ posts, userId, likedPostIds, followingUserIds }: PostListPro
   return (
     <ul className={styles.list}>
       {posts.map((post) => (
-        <PostCard
-          key={post.id}
-          post={post}
-          userId={userId}
-          likedPostIds={likedPostIds}
-          followingUserIds={followingUserIds}
-        />
+        <PostCard key={post.id} post={post} />
       ))}
     </ul>
   );

--- a/src/contexts/TimelineContext.tsx
+++ b/src/contexts/TimelineContext.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { createContext, useContext } from 'react';
+
+export type TimelineContextType = {
+  userId: string | null;
+  likedPostIds: Set<number>;
+  followingUserIds: Set<string>;
+};
+
+export const TimelineContext = createContext<TimelineContextType | undefined>(undefined);
+
+export const useTimeline = () => {
+  const context = useContext(TimelineContext);
+  if (context === undefined) {
+    throw new Error('useTimeline must be used within a TimelineContext provider');
+  }
+  return context;
+};


### PR DESCRIPTION
## 概要

HomePage -> PostList -> PostCard というコンポーネント構造で発生していたプロップドリルを、React Context APIを導入することで解消しました。

### 実装したこと

-   `TimelineContext`を新規作成し、タイムライン全体で共有する状態（`userId`, `likedPostIds`など）を管理するようにしました。
-   `PostCard`では`useContext`フック（をラップした`useTimeline`）を用いて、Contextから直接データを取得するように修正しました。
-   中間コンポーネントである`PostList`から、不要になったpropsの受け渡し処理を削除し、コードをシンプルにしました。