### PR TITLE
refactor: PostCardを複数の子コンポーネントに分割

### DIFF
--- a/src/components/features/posts/PostCard/DeletePostButton/DeletePostButton.tsx
+++ b/src/components/features/posts/PostCard/DeletePostButton/DeletePostButton.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+
+import Button from '@/components/ui/Button/Button';
+import ConfirmModal from '@/components/ui/ConfirmModal/ConfirmModal';
+import { deletePost } from '@/lib/actions';
+
+type DeletePostButtonProps = {
+  postId: number;
+};
+
+export const DeletePostButton = ({ postId }: DeletePostButtonProps) => {
+  // モーダルの開閉状態の判定
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  // 投稿の削除処理
+  const handleDeleteConfirm = async () => {
+    await deletePost(postId);
+    setIsModalOpen(false);
+  };
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="secondary"
+        size="small"
+        onClick={() => {
+          setIsModalOpen(true);
+        }}
+      >
+        削除
+      </Button>
+
+      <ConfirmModal
+        isOpen={isModalOpen}
+        onClose={() => {
+          setIsModalOpen(false);
+        }}
+        onConfirm={handleDeleteConfirm}
+        title="投稿を削除"
+      >
+        <p>この操作は取り消せません。本当にこの投稿を削除しますか？</p>
+      </ConfirmModal>
+    </>
+  );
+};

--- a/src/components/features/posts/PostCard/FollowButton/FollowButton.tsx
+++ b/src/components/features/posts/PostCard/FollowButton/FollowButton.tsx
@@ -1,0 +1,45 @@
+import toast from 'react-hot-toast';
+
+import Button from '@/components/ui/Button/Button';
+import { useTimeline } from '@/contexts/TimelineContext';
+import { followUser, unfollowUser } from '@/lib/actions';
+
+type FollowButtonProps = {
+  targetUserId: string | null;
+};
+
+export const FollowButton = ({ targetUserId }: FollowButtonProps) => {
+  const { followingUserIds } = useTimeline();
+
+  // 現在の投稿の投稿者が、ログインユーザーのフォローリストに含まれているかを判定
+  const isFollowing = targetUserId ? followingUserIds.has(targetUserId) : false;
+
+  const handleFollow = async () => {
+    if (!targetUserId) return;
+    try {
+      if (isFollowing) {
+        await unfollowUser(targetUserId);
+      } else {
+        await followUser(targetUserId);
+      }
+    } catch (error) {
+      if (error instanceof Error) {
+        toast.error(error.message);
+      } else {
+        console.error(error);
+        toast.error('エラーが発生しました。時間をおいて再度お試しください。');
+      }
+    }
+  };
+
+  return (
+    <Button
+      type="button"
+      variant={isFollowing ? 'primary' : 'secondary'}
+      size="small"
+      onClick={handleFollow}
+    >
+      {isFollowing ? 'フォロー中' : 'フォローする'}
+    </Button>
+  );
+};

--- a/src/components/features/posts/PostCard/LikeButton/LikeButton.module.scss
+++ b/src/components/features/posts/PostCard/LikeButton/LikeButton.module.scss
@@ -1,0 +1,22 @@
+// いいねセクション（アイコンと数）
+.likeSection {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: $color-gray-dark;
+}
+
+// いいねボタンのスタイル
+.likeButton {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font-size: 1.25rem;
+  color: $color-gray-dark;
+  transition: color 0.2s;
+
+  &:hover {
+    color: darken($color-gray-dark, 20%);
+  }
+}

--- a/src/components/features/posts/PostCard/LikeButton/LikeButton.tsx
+++ b/src/components/features/posts/PostCard/LikeButton/LikeButton.tsx
@@ -1,0 +1,47 @@
+import toast from 'react-hot-toast';
+import { FaHeart, FaRegHeart } from 'react-icons/fa';
+
+import { useTimeline } from '@/contexts/TimelineContext';
+import { likePost, unlikePost } from '@/lib/actions';
+import { type PostWithProfile } from '@/types';
+
+import styles from './LikeButton.module.scss';
+
+type likeButtonProps = {
+  post: PostWithProfile;
+};
+
+export const LikeButton = ({ post }: likeButtonProps) => {
+  const { likedPostIds } = useTimeline();
+
+  // いいねの数
+  const likeCount = post.likes[0]?.count ?? 0;
+  // いいねをした投稿か判定
+  const isLiked = likedPostIds.has(post.id);
+
+  const handleLike = async () => {
+    try {
+      if (isLiked) {
+        await unlikePost(post.id);
+      } else {
+        await likePost(post.id);
+      }
+    } catch (error) {
+      if (error instanceof Error) {
+        toast.error(error.message);
+      } else {
+        console.error(error);
+        toast.error('エラーが発生しました。時間をおいて再度お試しください。');
+      }
+    }
+  };
+
+  return (
+    <div className={styles.likeSection}>
+      <button className={styles.likeButton} type="button" onClick={handleLike}>
+        {isLiked ? <FaHeart color="red" /> : <FaRegHeart />}
+      </button>
+      <span>{likeCount}</span>
+    </div>
+  );
+};

--- a/src/components/features/posts/PostCard/PostCard.module.scss
+++ b/src/components/features/posts/PostCard/PostCard.module.scss
@@ -36,29 +36,6 @@
   align-items: center;
 }
 
-// いいねセクション（アイコンと数）
-.likeSection {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  color: $color-gray-dark;
-}
-
-// いいねボタンのスタイル
-.likeButton {
-  background: none;
-  border: none;
-  padding: 0;
-  cursor: pointer;
-  font-size: 1.25rem;
-  color: $color-gray-dark;
-  transition: color 0.2s;
-
-  &:hover {
-    color: darken($color-gray-dark, 20%);
-  }
-}
-
 // 投稿時刻
 .time {
   display: flex;

--- a/src/components/features/posts/PostCard/PostCard.tsx
+++ b/src/components/features/posts/PostCard/PostCard.tsx
@@ -1,15 +1,11 @@
 'use client';
 
-import { useState } from 'react';
-import toast from 'react-hot-toast';
-import { FaHeart, FaRegHeart } from 'react-icons/fa';
-
-import Button from '@/components/ui/Button/Button';
-import ConfirmModal from '@/components/ui/ConfirmModal/ConfirmModal';
 import { useTimeline } from '@/contexts/TimelineContext';
-import { deletePost, followUser, likePost, unfollowUser, unlikePost } from '@/lib/actions';
 import { type PostWithProfile } from '@/types';
 
+import { DeletePostButton } from './DeletePostButton/DeletePostButton';
+import { FollowButton } from './FollowButton/FollowButton';
+import { LikeButton } from './LikeButton/LikeButton';
 import styles from './PostCard.module.scss';
 
 type PostCardProps = {
@@ -22,63 +18,10 @@ type PostCardProps = {
  */
 const PostCard = ({ post }: PostCardProps) => {
   // Contextからデータを取得
-  const { userId, likedPostIds, followingUserIds } = useTimeline();
+  const { userId } = useTimeline();
 
   // 現在のユーザーが投稿者かどうかを判定
   const isOwnPost = userId && userId === post.user_id;
-
-  // モーダルの開閉状態の判定
-  const [isModalOpen, setIsModalOpen] = useState(false);
-
-  // いいねの数
-  const likeCount = post.likes[0]?.count ?? 0;
-
-  // いいねをした投稿か判定
-  const isLiked = likedPostIds.has(post.id);
-
-  const handleLike = async () => {
-    try {
-      if (isLiked) {
-        await unlikePost(post.id);
-      } else {
-        await likePost(post.id);
-      }
-    } catch (error) {
-      if (error instanceof Error) {
-        toast.error(error.message);
-      } else {
-        console.error(error);
-        toast.error('エラーが発生しました。時間をおいて再度お試しください。');
-      }
-    }
-  };
-
-  // 現在の投稿の投稿者が、ログインユーザーのフォローリストに含まれているかを判定
-  const isFollowing = post.user_id ? followingUserIds.has(post.user_id) : false;
-
-  const handleFollow = async () => {
-    if (!post.user_id) return;
-    try {
-      if (isFollowing) {
-        await unfollowUser(post.user_id);
-      } else {
-        await followUser(post.user_id);
-      }
-    } catch (error) {
-      if (error instanceof Error) {
-        toast.error(error.message);
-      } else {
-        console.error(error);
-        toast.error('エラーが発生しました。時間をおいて再度お試しください。');
-      }
-    }
-  };
-
-  // 投稿の削除処理
-  const handleDeleteConfirm = async () => {
-    await deletePost(post.id);
-    setIsModalOpen(false);
-  };
 
   return (
     <li>
@@ -86,16 +29,7 @@ const PostCard = ({ post }: PostCardProps) => {
         <header className={styles.header}>
           <span className={styles.userName}>{post.profiles?.user_name ?? '名無しさん'}</span>
           {/* 投稿者本人以外のみフォローボタンを表示 */}
-          {!isOwnPost && (
-            <Button
-              type="button"
-              variant={isFollowing ? 'primary' : 'secondary'}
-              size="small"
-              onClick={handleFollow}
-            >
-              {isFollowing ? 'フォロー中' : 'フォローする'}
-            </Button>
-          )}
+          {!isOwnPost && <FollowButton targetUserId={post.user_id} />}
         </header>
 
         <main>
@@ -104,42 +38,15 @@ const PostCard = ({ post }: PostCardProps) => {
 
         <footer>
           <div className={styles.actions}>
-            <div className={styles.likeSection}>
-              <button className={styles.likeButton} type="button" onClick={handleLike}>
-                {isLiked ? <FaHeart color="red" /> : <FaRegHeart />}
-              </button>
-              <span>{likeCount}</span>
-            </div>
+            <LikeButton post={post} />
             {/* 投稿者本人のみ削除ボタンを表示 */}
-            {isOwnPost && (
-              <Button
-                type="button"
-                variant="secondary"
-                size="small"
-                onClick={() => {
-                  setIsModalOpen(true);
-                }}
-              >
-                削除
-              </Button>
-            )}
+            {isOwnPost && <DeletePostButton postId={post.id} />}
           </div>
           <time dateTime={post.created_at} className={styles.time}>
             {new Date(post.created_at).toLocaleString()}
           </time>
         </footer>
       </article>
-
-      <ConfirmModal
-        isOpen={isModalOpen}
-        onClose={() => {
-          setIsModalOpen(false);
-        }}
-        onConfirm={handleDeleteConfirm}
-        title="投稿を削除"
-      >
-        <p>この操作は取り消せません。本当にこの投稿を削除しますか？</p>
-      </ConfirmModal>
     </li>
   );
 };


### PR DESCRIPTION
## 概要

`PostCard`コンポーネントが、複数の責務を持っており複雑化していたため、関心事ごとに小さなコンポーネントに分割するリファクタリングを行いました。

### 実装したこと

-   いいね機能のロジックとUIを`LikeButton`コンポーネントに分離しました。
-   フォロー機能のロジックとUIを`FollowButton`コンポーネントに分離しました。
-   削除機能のロジック、UI、確認モーダルを`DeletePostButton`コンポーネントに分離しました。