### PR TITLE
refactor: Context Providerをクライアントコンポーネントに分離

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -1,9 +1,5 @@
-import PostForm from '@/components/features/posts/PostForm/PostForm';
-import PostList from '@/components/features/posts/PostList/PostList';
-import { TimelineContext } from '@/contexts/TimelineContext';
+import { Timeline } from '@/components/features/timeline/Timeline';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
-
-import styles from './page.module.scss';
 
 /**
  * メインページ（ホーム・タイムライン）
@@ -63,22 +59,12 @@ const HomePage = async () => {
     }
   }
 
-  const TimelineContextValue = {
+  const timelineContextValue = {
     userId: user?.id ?? null,
     likedPostIds,
     followingUserIds,
   };
 
-  return (
-    <>
-      <header className={styles.header}>
-        <h2 className={styles.title}>タイムライン</h2>
-        <PostForm />
-      </header>
-      <TimelineContext value={TimelineContextValue}>
-        <PostList posts={posts} />
-      </TimelineContext>
-    </>
-  );
+  return <Timeline posts={posts} timelineContextValue={timelineContextValue} />;
 };
 export default HomePage;

--- a/src/components/features/timeline/Timeline.tsx
+++ b/src/components/features/timeline/Timeline.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import styles from '@/app/(main)/page.module.scss';
+import PostForm from '@/components/features/posts/PostForm/PostForm';
+import PostList from '@/components/features/posts/PostList/PostList';
+import { TimelineContext, type TimelineContextType } from '@/contexts/TimelineContext';
+import { type PostWithProfile } from '@/types';
+
+// HomePageから受け取る全てのpropsの型を定義
+type TimelineProps = {
+  posts: PostWithProfile[] | null;
+  timelineContextValue: TimelineContextType;
+};
+
+export const Timeline = ({ posts, timelineContextValue }: TimelineProps) => {
+  return (
+    <>
+      <header className={styles.header}>
+        <h2 className={styles.title}>タイムライン</h2>
+        <PostForm />
+      </header>
+      <TimelineContext value={timelineContextValue}>
+        <PostList posts={posts} />
+      </TimelineContext>
+    </>
+  );
+};


### PR DESCRIPTION
## 概要

サーバーコンポーネントから直接React Context Providerをレンダリングしようとした際に発生するランタイムエラーを解消しました。

### 実装したこと

-   データ取得を行うサーバーコンポーネント(`HomePage`)と、UIの表示およびContextの提供を行う新しいクライアントコンポーネント(`Timeline`)に責務を分割しました。