### PR TITLE
feat: ユーザープロフィールページ（投稿・いいね一覧）を実装

### DIFF
--- a/src/app/(main)/profile/[userId]/page.tsx
+++ b/src/app/(main)/profile/[userId]/page.tsx
@@ -1,0 +1,100 @@
+import { ProfileClient } from '@/components/features/profile/ProfileClient/ProfileClient';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+
+/**
+ * プロフィールページ（サーバーコンポーネント）
+ * ページの表示に必要なデータをすべて取得し、クライアントコンポーネントに渡す
+ */
+const ProfilePage = async ({ params }: { params: { userId: string } }) => {
+  const { userId } = params;
+  const supabase = await createSupabaseServerClient();
+
+  const {
+    data: { user: loggedInUser },
+  } = await supabase.auth.getUser();
+
+  // Context用: ログインユーザー自身のいいね・フォロー情報を取得
+  const [loggedInUserLikesResult, loggedInUserFollowsResult] = loggedInUser
+    ? await Promise.all([
+        supabase.from('likes').select('post_id').eq('user_id', loggedInUser.id),
+        supabase.from('follows').select('following_id').eq('follower_id', loggedInUser.id),
+      ])
+    : [
+        { data: [], error: null },
+        { data: [], error: null },
+      ];
+
+  const loggedInUserLikedPostIds = new Set(
+    (loggedInUserLikesResult.data ?? [])
+      .map((like) => like.post_id)
+      .filter((id): id is number => id !== null),
+  );
+  const loggedInUserFollowingIds = new Set(
+    (loggedInUserFollowsResult.data ?? [])
+      .map((follow) => follow.following_id)
+      .filter((id): id is string => id !== null),
+  );
+
+  // ページ表示用: プロフィール対象ユーザーがいいねした投稿ID一覧を取得
+  const { data: likedPostObjects } = await supabase
+    .from('likes')
+    .select('post_id')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false });
+
+  const profileUserLikedPostIds =
+    likedPostObjects?.map((likedPost) => likedPost.post_id).filter((id) => id !== null) ?? [];
+
+  // ページに必要なデータを並行取得
+  const [
+    profileResult,
+    followingCountResult,
+    followerCountResult,
+    usersPostsResult,
+    likedPostsResult,
+  ] = await Promise.all([
+    supabase.from('profiles').select('user_name, current_gobi').eq('id', userId).single(),
+    supabase.from('follows').select('*', { count: 'exact', head: true }).eq('follower_id', userId),
+    supabase.from('follows').select('*', { count: 'exact', head: true }).eq('following_id', userId),
+    supabase
+      .from('posts')
+      .select('*, profiles(user_name), likes(count)')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false }),
+    supabase
+      .from('posts')
+      .select('*, profiles(user_name), likes(count)')
+      .in('id', profileUserLikedPostIds)
+      .order('created_at', { ascending: false }),
+  ]);
+
+  const profile = profileResult.data;
+  const followingCount = followingCountResult.count ?? 0;
+  const followerCount = followerCountResult.count ?? 0;
+  const usersPosts = usersPostsResult.data;
+  const likedPosts = likedPostsResult.data;
+
+  const timelineContextValue = {
+    userId: loggedInUser?.id ?? null,
+    likedPostIds: loggedInUserLikedPostIds,
+    followingUserIds: loggedInUserFollowingIds,
+  };
+
+  if (!profile) {
+    return <div>ユーザーが見つかりません</div>;
+  }
+
+  return (
+    <ProfileClient
+      userName={profile.user_name}
+      currentGobi={profile.current_gobi}
+      followingCount={followingCount}
+      followerCount={followerCount}
+      userPosts={usersPosts}
+      likedPosts={likedPosts}
+      timelineContextValue={timelineContextValue}
+    />
+  );
+};
+
+export default ProfilePage;

--- a/src/components/features/profile/ProfileClient/ProfileClient.module.scss
+++ b/src/components/features/profile/ProfileClient/ProfileClient.module.scss
@@ -1,0 +1,91 @@
+@use 'styles/variables' as *;
+
+// プロフィールページ全体のコンテナ
+.profile {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.profileHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.5rem;
+  background-color: $color-white;
+  border: 1px solid $color-gray-medium;
+  border-radius: 8px;
+}
+
+// ユーザー名
+.userName {
+  margin-bottom: 0.5rem;
+  font-size: 1.8rem;
+  font-weight: bold;
+  word-break: break-all;
+}
+
+// 語尾
+.gobi {
+  color: $color-gray-dark;
+}
+
+// フォロー・フォロワー数のセクション
+.stats {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.stat {
+  display: flex;
+  align-items: baseline;
+  gap: 0.25rem;
+}
+
+.statValue {
+  font-size: 1.2rem;
+  font-weight: bold;
+}
+
+.statLabel {
+  font-size: 0.9rem;
+  color: $color-gray-dark;
+}
+
+// タブボタンのコンテナ
+.tabs {
+  display: flex;
+  border-bottom: 1px solid $color-gray-medium;
+}
+
+// 個別のタブボタン
+.tab {
+  margin-bottom: -1px;
+  padding: 0.75rem 1.5rem;
+  font-size: 1rem;
+  font-weight: bold;
+  color: $color-gray-dark;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  transition:
+    color 0.2s,
+    border-color 0.2s;
+
+  &:hover {
+    color: darken($color-gray-dark, 20%);
+  }
+}
+
+// アクティブなタブボタンのスタイル
+.tabActive {
+  color: $color-primary;
+  border-bottom-color: $color-primary;
+}
+
+// 投稿一覧が表示されるコンテンツエリア
+.content {
+  margin-top: 1.5rem;
+}

--- a/src/components/features/profile/ProfileClient/ProfileClient.tsx
+++ b/src/components/features/profile/ProfileClient/ProfileClient.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useState } from 'react';
+
+import PostList from '@/components/features/posts/PostList/PostList';
+import { TimelineContext, type TimelineContextType } from '@/contexts/TimelineContext';
+import { PostWithProfile } from '@/types';
+
+import styles from './ProfileClient.module.scss';
+
+type ProfileClientProps = {
+  userName: string | null;
+  currentGobi: string | null;
+  followingCount: number;
+  followerCount: number;
+  userPosts: PostWithProfile[] | null;
+  likedPosts: PostWithProfile[] | null;
+  timelineContextValue: TimelineContextType;
+};
+
+/**
+ * プロフィールページのUIを描画するクライアントコンポーネント
+ * サーバーから受け取ったデータを基に、タブの状態管理などを行う
+ */
+export const ProfileClient = (props: ProfileClientProps) => {
+  const {
+    userName,
+    currentGobi,
+    followingCount,
+    followerCount,
+    userPosts,
+    likedPosts,
+    timelineContextValue,
+  } = props;
+
+  // 表示するタブ（'posts' or 'likes'）の状態
+  const [activeTab, setActiveTab] = useState('posts');
+
+  /**
+   * タブがアクティブかどうかに基づいて動的なクラス名を生成する
+   * @param tabName 'posts' or 'likes'
+   * @returns {string} CSSクラス名の文字列
+   */
+  const getTabClassName = (tabName: string) => {
+    return `${styles.tab} ${activeTab === tabName ? styles.tabActive : ''}`;
+  };
+
+  return (
+    <section className={styles.profile}>
+      <header className={styles.profileHeader}>
+        <div className={styles.mainInfo}>
+          <h2 className={styles.userName}>{userName}</h2>
+          <p className={styles.gobi}>語尾：{currentGobi}</p>
+        </div>
+        <div className={styles.stats}>
+          <div className={styles.stat}>
+            <span className={styles.statValue}>{followingCount}</span>
+            <span className={styles.statLabel}>フォロー</span>
+          </div>
+          <div className={styles.stat}>
+            <span className={styles.statValue}>{followerCount}</span>
+            <span className={styles.statLabel}>フォロワー</span>
+          </div>
+        </div>
+      </header>
+
+      <div className={styles.tabs}>
+        <button
+          type="button"
+          className={getTabClassName('posts')}
+          onClick={() => {
+            setActiveTab('posts');
+          }}
+        >
+          投稿
+        </button>
+        <button
+          type="button"
+          className={getTabClassName('likes')}
+          onClick={() => {
+            setActiveTab('likes');
+          }}
+        >
+          いいね
+        </button>
+      </div>
+
+      <div className={styles.content}>
+        {/* PostList内部のコンポーネントがContextを必要とするため、ここで提供する */}
+        <TimelineContext value={timelineContextValue}>
+          {activeTab === 'posts' && <PostList posts={userPosts} />}
+          {activeTab === 'likes' && <PostList posts={likedPosts} />}
+        </TimelineContext>
+      </div>
+    </section>
+  );
+};


### PR DESCRIPTION
## 概要

ユーザーのプロフィール情報を表示するページを新規に作成しました。このページでは、ユーザーの投稿一覧といいねした投稿一覧をタブで切り替えて表示できます。

### 実装したこと

- Next.jsの動的ルートで`/profile/[userId]`ページを作成し、データ取得をサーバーコンポーネント（`ProfilePage.tsx`）、UI表示をクライアントコンポーネント（`ProfileClient.tsx`）に分割。
- ユーザーの投稿一覧といいねした投稿一覧を表示するため、`useState`で状態を管理するタブUIを実装。
- プロフィール情報、フォロー数、投稿データなどを`Promise.all`で並行取得。