### PR TITLE
feat: プロフィールページへのリンクを追加

### DIFF
--- a/src/components/features/posts/PostCard/PostCard.module.scss
+++ b/src/components/features/posts/PostCard/PostCard.module.scss
@@ -16,6 +16,17 @@
   gap: 1rem;
 }
 
+// ユーザー名用のリンク
+.userNameLink {
+  color: inherit; // 親要素の文字色を継承する
+  text-decoration: none; // 下線を削除
+
+  // ホバーした時だけ下線を表示して、リンクであることを分かりやすくする
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
 // ユーザー名
 .userName {
   font-weight: bold;

--- a/src/components/features/posts/PostCard/PostCard.tsx
+++ b/src/components/features/posts/PostCard/PostCard.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import Link from 'next/link';
+
 import { useTimeline } from '@/contexts/TimelineContext';
 import { type PostWithProfile } from '@/types';
 
@@ -27,7 +29,9 @@ const PostCard = ({ post }: PostCardProps) => {
     <li>
       <article className={styles.card}>
         <header className={styles.header}>
-          <span className={styles.userName}>{post.profiles?.user_name ?? '名無しさん'}</span>
+          <Link href={`/profile/${post.user_id}`} className={styles.userNameLink}>
+            <span className={styles.userName}>{post.profiles?.user_name ?? '名無しさん'}</span>
+          </Link>
           {/* 投稿者本人以外のみフォローボタンを表示 */}
           {!isOwnPost && <FollowButton targetUserId={post.user_id} />}
         </header>

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -26,6 +26,9 @@ const Header = async () => {
       {/* ログイン済みユーザー向けナビゲーション */}
       {session && (
         <nav className={styles.nav}>
+          <Button href={`/profile/${session.user.id}`} variant="secondary">
+            マイプロフィール
+          </Button>
           <Button href="/account/profile" variant="secondary">
             プロフィール設定
           </Button>


### PR DESCRIPTION
## 概要

完成したプロフィールページに、アプリケーションのUI上からアクセスできるようにするための導線を作成しました。

### 実装したこと

- 投稿カード（`PostCard.tsx`）のユーザー名をLinkコンポーネントに変更し、各投稿から投稿者のプロフィールページへ移動できるようにした。
- ヘッダー（`Header.tsx`）に「マイプロフィール」ボタンを追加し、ログイン中のユーザーが自身のプロフィールページへ移動できるようにした。
