### PR TITLE
feat: ヘッダーからの投稿検索機能を追加

### DIFF
--- a/src/app/(main)/search/page.module.scss
+++ b/src/app/(main)/search/page.module.scss
@@ -1,0 +1,4 @@
+.title {
+  font-size: 1.8rem;
+  margin-bottom: 1.5rem;
+}

--- a/src/app/(main)/search/page.tsx
+++ b/src/app/(main)/search/page.tsx
@@ -1,0 +1,74 @@
+import { SearchResultClient } from '@/components/features/search/SearchResultClient/SearchResultClient';
+import { searchPosts } from '@/lib/actions';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+
+import styles from './page.module.scss';
+
+type SearchPageProps = {
+  searchParams: { q: string };
+};
+
+const SearchPage = async ({ searchParams }: SearchPageProps) => {
+  const searchResultPosts = await searchPosts(searchParams.q);
+  const supabase = await createSupabaseServerClient();
+
+  // ログインユーザーの情報を取得
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  // ログインユーザーがいいねした投稿IDを格納するSet
+  let likedPostIds = new Set<number>();
+
+  // ログインしている場合のみ、いいねリストを取得
+  if (user) {
+    const { data: likedPosts } = await supabase
+      .from('likes')
+      .select('post_id')
+      .eq('user_id', user.id);
+
+    if (likedPosts) {
+      likedPostIds = new Set(
+        likedPosts
+          .filter((like): like is { post_id: number } => like.post_id !== null)
+          .map((like) => like.post_id),
+      );
+    }
+  }
+
+  // ログインユーザーがフォローしたユーザーIDを格納するSet
+  let followingUserIds = new Set<string>();
+
+  // ログインしている場合のみ、フォローリストを取得
+  if (user) {
+    const { data: followingUsers } = await supabase
+      .from('follows')
+      .select('following_id')
+      .eq('follower_id', user.id);
+
+    if (followingUsers) {
+      followingUserIds = new Set(
+        followingUsers
+          .filter(
+            (following): following is { following_id: string } => following.following_id !== null,
+          )
+          .map((following) => following.following_id),
+      );
+    }
+  }
+
+  const timelineContextValue = {
+    userId: user?.id ?? null,
+    likedPostIds,
+    followingUserIds,
+  };
+
+  return (
+    <>
+      <h2 className={styles.title}>{searchParams.q}の検索結果</h2>
+      <SearchResultClient posts={searchResultPosts} timelineContextValue={timelineContextValue} />
+    </>
+  );
+};
+
+export default SearchPage;

--- a/src/components/features/posts/PostCard/PostCard.module.scss
+++ b/src/components/features/posts/PostCard/PostCard.module.scss
@@ -50,13 +50,3 @@
   justify-content: space-between;
   align-items: center;
 }
-
-// 投稿時刻
-.time {
-  display: flex;
-  justify-content: flex-end;
-  margin-top: 0.5rem;
-  font-size: 0.8rem;
-  color: $color-gray-medium;
-  white-space: nowrap; // 時刻の改行を防ぐ
-}

--- a/src/components/features/posts/PostCard/PostCard.tsx
+++ b/src/components/features/posts/PostCard/PostCard.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 
 import { Avatar } from '@/components/ui/Avatar/Avatar';
+import { ClientFormattedTime } from '@/components/ui/ClientFormattedTime/ClientFormattedTime';
 import { useTimeline } from '@/contexts/TimelineContext';
 import { type PostWithProfile } from '@/types';
 
@@ -48,9 +49,7 @@ const PostCard = ({ post }: PostCardProps) => {
             {/* 投稿者本人のみ削除ボタンを表示 */}
             {isOwnPost && <DeletePostButton postId={post.id} />}
           </div>
-          <time dateTime={post.created_at} className={styles.time}>
-            {new Date(post.created_at).toLocaleString()}
-          </time>
+          <ClientFormattedTime dateString={post.created_at} />
         </footer>
       </article>
     </li>

--- a/src/components/features/search/SearchBar/SearchBar.module.scss
+++ b/src/components/features/search/SearchBar/SearchBar.module.scss
@@ -1,0 +1,49 @@
+@use 'styles/variables' as *;
+
+// フォーム全体のコンテナ
+.searchForm {
+  display: flex;
+  align-items: center;
+  border: 1px solid $color-gray-medium;
+  border-radius: 9999px; // 角を丸くしてカプセル型に
+  background-color: $color-white;
+  overflow: hidden; // 子要素がはみ出ないように
+
+  // フォーカス時にフォーム全体をハイライト
+  &:focus-within {
+    border-color: $color-primary;
+    box-shadow: 0 0 0 2px rgba($color-primary, 0.2);
+  }
+}
+
+// 検索キーワードの入力欄
+.searchInput {
+  border: none;
+  outline: none;
+  padding: 0.5rem 1rem;
+  font-size: 0.9rem;
+  width: 200px;
+  background-color: transparent;
+
+  &::placeholder {
+    color: $color-gray-medium;
+  }
+}
+
+// 検索実行ボタン
+.searchButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5rem;
+  padding-right: 0.75rem; // アイコンの右側に少し余白を追加
+  border: none;
+  background-color: transparent;
+  cursor: pointer;
+  color: $color-gray-dark;
+  transition: color 0.2s;
+
+  &:hover {
+    color: $color-primary;
+  }
+}

--- a/src/components/features/search/SearchBar/SearchBar.tsx
+++ b/src/components/features/search/SearchBar/SearchBar.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { FaSearch } from 'react-icons/fa';
+
+import styles from './SearchBar.module.scss';
+
+/**
+ * ヘッダーに表示される検索バーコンポーネント
+ */
+export const SearchBar = () => {
+  const router = useRouter();
+  // ユーザーの入力を管理するstate
+  const [query, setQuery] = useState<string>('');
+
+  /**
+   * フォーム送信時の処理
+   * 入力されたキーワードをクエリパラメータとして、検索結果ページに遷移する
+   */
+  const handleSearch = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!query) {
+      return;
+    }
+    router.push(`/search?q=${query}`);
+  };
+
+  return (
+    <form className={styles.searchForm} onSubmit={handleSearch}>
+      <input
+        type="text"
+        className={styles.searchInput}
+        placeholder="投稿を検索..."
+        value={query}
+        onChange={(e) => {
+          setQuery(e.target.value);
+        }}
+      />
+      <button type="submit" className={styles.searchButton} aria-label="検索実行">
+        <FaSearch size={16} />
+      </button>
+    </form>
+  );
+};

--- a/src/components/features/search/SearchResultClient/SearchResultClient.tsx
+++ b/src/components/features/search/SearchResultClient/SearchResultClient.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import PostList from '@/components/features/posts/PostList/PostList';
+import { TimelineContext, type TimelineContextType } from '@/contexts/TimelineContext';
+import { type PostWithProfile } from '@/types';
+
+type SearchResultClientProps = {
+  posts: PostWithProfile[] | null;
+  timelineContextValue: TimelineContextType;
+};
+
+/**
+ * 検索結果の投稿一覧と、それらが依存するContextを提供するクライアントコンポーネント
+ */
+export const SearchResultClient = ({ posts, timelineContextValue }: SearchResultClientProps) => {
+  return (
+    <TimelineContext.Provider value={timelineContextValue}>
+      <PostList posts={posts} />
+    </TimelineContext.Provider>
+  );
+};

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 
+import { SearchBar } from '@/components/features/search/SearchBar/SearchBar';
 import { Avatar } from '@/components/ui/Avatar/Avatar';
 import Button from '@/components/ui/Button/Button';
 import { logout } from '@/lib/actions';
@@ -44,6 +45,8 @@ const Header = async () => {
           <Link href={`/profile/${user.id}`} className={styles.avatarLink}>
             <Avatar avatarUrl={profile?.avatar_url ?? null} size={40} />
           </Link>
+
+          <SearchBar />
         </nav>
       )}
     </header>

--- a/src/components/ui/ClientFormattedTime/ClientFormattedTime.module.scss
+++ b/src/components/ui/ClientFormattedTime/ClientFormattedTime.module.scss
@@ -1,0 +1,10 @@
+@use 'styles/variables' as *;
+
+.time {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 0.5rem;
+  font-size: 0.8rem;
+  color: $color-gray-medium;
+  white-space: nowrap;
+}

--- a/src/components/ui/ClientFormattedTime/ClientFormattedTime.tsx
+++ b/src/components/ui/ClientFormattedTime/ClientFormattedTime.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import styles from './ClientFormattedTime.module.scss';
+
+type ClientFormattedTimeProps = {
+  dateString: string;
+};
+
+/**
+ * サーバーとクライアントの日時フォーマットの差異による
+ * Hydration Errorを防ぐためのクライアントコンポーネント
+ */
+export const ClientFormattedTime = ({ dateString }: ClientFormattedTimeProps) => {
+  const [formattedDate, setFormattedDate] = useState('');
+
+  useEffect(() => {
+    setFormattedDate(new Date(dateString).toLocaleString());
+  }, [dateString]);
+
+  if (!formattedDate) {
+    return null;
+  }
+
+  return (
+    <time dateTime={dateString} className={styles.time}>
+      {formattedDate}
+    </time>
+  );
+};

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -344,3 +344,24 @@ export const deleteAvatar = async () => {
   revalidatePath('/account/profile');
   revalidatePath(`/profile/${user.id}`);
 };
+
+export const searchPosts = async (query: string) => {
+  if (!query) {
+    return [];
+  }
+
+  const { supabase } = await getAuthenticatedClient();
+
+  const { data: posts, error } = await supabase
+    .from('posts')
+    .select('*, profiles(user_name, avatar_url), likes(count)')
+    .ilike('content', `%${query}%`)
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    console.error(error);
+    throw new Error('検索に失敗しました。');
+  }
+
+  return posts;
+};


### PR DESCRIPTION
## 概要

ヘッダーに設置した検索バーから、投稿の本文をキーワードで検索できる機能を追加しました。
検索結果は専用ページ(`/search`)に表示されます。

## 実装したこと

### 1. サーバーサイド
- **`searchPosts`サーバーアクションの追加 (`lib/actions.ts`)**
  - Supabaseの`.ilike()`を利用し、キーワードに部分一致する投稿を大文字・小文字を区別せずに検索するロジックを実装しました。

### 2. フロントエンド
- **`SearchBar`コンポーネントの作成 (`/components/features/search`)**
  - ユーザーがキーワードを入力し、検索を実行するためのUIコンポーネントです。
  - `Header`コンポーネントに統合し、全ページから検索を実行できるようにしました。
- **検索結果ページの作成 (`/app/(main)/search`)**
  - URLのクエリパラメータ (`?q=...`) を受け取り、`searchPosts`アクションを実行して結果を表示するサーバーコンポーネント (`page.tsx`) を作成しました。
- **`SearchResultClient`コンポーネントの作成**
  - サーバーコンポーネントからクライアント専用の`Context`を安全に利用するため、描画ロジックをこのクライアントコンポーネントに分離しました。

### 3. バグ修正
- **Hydration Errorの解消**
  - `.toLocaleString()` が原因で発生していたサーバーとクライアントのHTML不一致問題を、日時フォーマットを専門に行うクライアントコンポーネント (`ClientFormattedTime`) を作成することで解決しました。