### PR TITLE
refactor: Context取得ロジックを共通のヘルパー関数に分離

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,43 @@
+// src/lib/utils.ts
+
+import { type SupabaseClient, type User } from '@supabase/supabase-js';
+
+/**
+ * タイムライン系のコンポーネントで必要となるContextの値を生成するヘルパー関数
+ * @param supabase - Supabaseクライアントのインスタンス
+ * @param user - 現在のログインユーザー情報（Userオブジェクトまたはnull）
+ */
+export const getTimelineContextValue = async (supabase: SupabaseClient, user: User | null) => {
+  let likedPostIds = new Set<number>();
+  let followingUserIds = new Set<string>();
+
+  if (user) {
+    const [{ data: likedPosts }, { data: followingUsers }] = await Promise.all([
+      supabase.from('likes').select('post_id').eq('user_id', user.id),
+      supabase.from('follows').select('following_id').eq('follower_id', user.id),
+    ]);
+
+    if (likedPosts) {
+      likedPostIds = new Set(
+        likedPosts
+          .filter((like): like is { post_id: number } => like.post_id !== null)
+          .map((like) => like.post_id),
+      );
+    }
+    if (followingUsers) {
+      followingUserIds = new Set(
+        followingUsers
+          .filter(
+            (following): following is { following_id: string } => following.following_id !== null,
+          )
+          .map((following) => following.following_id),
+      );
+    }
+  }
+
+  return {
+    userId: user?.id ?? null,
+    likedPostIds,
+    followingUserIds,
+  };
+};


### PR DESCRIPTION
## 概要
`HomePage`と`SearchPage`で重複していた、タイムライン表示に必要なContext（いいね・フォロー情報）を取得するロジックを、共通のヘルパー関数 `getTimelineContextValue` に切り出しました。

## 変更したこと
- `lib/utils.ts` を新設し、`getTimelineContextValue` を定義。
- `page.tsx` と `search/page.tsx` を修正し、新しいヘルパー関数を呼び出すように変更。