### PR TITLE
fix: 無限スクロールで投稿が重複する不具合を修正

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -15,13 +15,16 @@ const HomePage = async () => {
     data: { user },
   } = await supabase.auth.getUser();
 
+  const PAGE_SIZE = 10;
+
   // 投稿データとContextの値を並行して取得
   const [{ data: posts }, timelineContextValue] = await Promise.all([
     supabase
       .from('posts')
       .select('*, profiles(user_name, avatar_url), likes(count)')
-      .order('created_at', { ascending: false }),
-    getTimelineContextValue(supabase, user), // 👈 共通関数を呼び出す
+      .order('created_at', { ascending: false })
+      .range(0, PAGE_SIZE - 1),
+    getTimelineContextValue(supabase, user),
   ]);
 
   return (

--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -43,11 +43,13 @@ const reducer = (state: State, action: Action): State => {
  * @returns 投稿リスト、ローディング状態、および監視対象に設定するref
  */
 export const useInfiniteScroll = (initialPosts: PostWithProfile[] | null) => {
+  const PAGE_SIZE = 10;
+
   const initialState: State = {
     posts: initialPosts ?? [],
     page: 1,
     isLoading: false,
-    hasMore: true,
+    hasMore: (initialPosts?.length ?? 0) === PAGE_SIZE,
   };
 
   const [state, dispatch] = useReducer(reducer, initialState);
@@ -61,8 +63,6 @@ export const useInfiniteScroll = (initialPosts: PostWithProfile[] | null) => {
   const { ref, inView } = useInView({
     threshold: 0,
   });
-
-  const PAGE_SIZE = 10;
 
   useEffect(() => {
     if (inView && !state.isLoading && state.hasMore) {


### PR DESCRIPTION
## 概要

タイムラインの無限スクロールにおいて、最後の投稿が重複して表示される不具合を修正しました。

## 原因

- **`HomePage`コンポーネント**: ページ初期表示時に、ページ分割せずに**全ての投稿**を取得していました。
- **`useInfiniteScroll`フック**: スクロール時に**次のページ**のデータを取得していました。

この2つのデータ取得ロジックの食い違いにより、`HomePage`が全件表示した後に、フックが最後の数件を再度取得・表示してしまっていました。

## 実装内容

- **`src/app/(main)/page.tsx`の修正**
  - Supabaseのクエリに`.range()`を追加し、サーバーサイドでの初期データ取得を**最初の1ページ分のみ**に限定しました。

- **`src/hooks/useInfiniteScroll.ts`の修正**
  - `initialState`の`hasMore`プロパティのロジックを更新しました。最初に取得した投稿の数がページサイズに満たない場合は、それ以上ないと判断し、不要な追加フェッチを防止します。