### PR TITLE
fix(timeline): 無限スクロール時の投稿消失バグを修正しUIを改善

### DIFF
--- a/src/features/posts/components/LikeButton/LikeButton.tsx
+++ b/src/features/posts/components/LikeButton/LikeButton.tsx
@@ -1,3 +1,6 @@
+'use client';
+
+import { useState } from 'react';
 import toast from 'react-hot-toast';
 import { FaHeart, FaRegHeart } from 'react-icons/fa';
 
@@ -7,26 +10,52 @@ import { type PostWithProfile } from '@/types';
 
 import styles from './LikeButton.module.scss';
 
-type likeButtonProps = {
+type LikeButtonProps = {
   post: PostWithProfile;
 };
 
-export const LikeButton = ({ post }: likeButtonProps) => {
+/**
+ * 投稿に対するいいね機能を提供するコンポーネント
+ * ユーザー体験向上のため、いいねの状態とカウントを即時反映する楽観的更新を実装
+ */
+export const LikeButton = ({ post }: LikeButtonProps) => {
   const { likedPostIds } = useTimeline();
-
-  // いいねの数
   const likeCount = post.likes[0]?.count ?? 0;
-  // いいねをした投稿か判定
-  const isLiked = likedPostIds.has(post.id);
 
+  // 楽観的更新用のUI状態
+  const [optimisticIsLiked, setOptimisticIsLiked] = useState(likedPostIds.has(post.id));
+  const [optimisticLikeCount, setOptimisticLikeCount] = useState(likeCount);
+
+  /**
+   * いいねボタンクリック時の処理
+   * サーバーへのリクエスト前にUIを即時更新し、エラー発生時は元の状態に戻す
+   */
   const handleLike = async () => {
+    // 1. 現在のUI状態をリクエスト前に保存
+    const originalIsLiked = optimisticIsLiked;
+    const originalLikeCount = optimisticLikeCount;
+
+    // 2. UIを即座に更新（楽観的更新）
+    if (originalIsLiked) {
+      setOptimisticIsLiked(false);
+      setOptimisticLikeCount((prev) => prev - 1);
+    } else {
+      setOptimisticIsLiked(true);
+      setOptimisticLikeCount((prev) => prev + 1);
+    }
+
     try {
-      if (isLiked) {
+      // 3. サーバーへリクエストを送信
+      if (originalIsLiked) {
         await unlikePost(post.id);
       } else {
         await likePost(post.id);
       }
     } catch (error) {
+      // 4. エラーが発生した場合、UIを元の状態にロールバック
+      setOptimisticIsLiked(originalIsLiked);
+      setOptimisticLikeCount(originalLikeCount);
+
       if (error instanceof Error) {
         toast.error(error.message);
       } else {
@@ -39,9 +68,9 @@ export const LikeButton = ({ post }: likeButtonProps) => {
   return (
     <div className={styles.likeSection}>
       <button className={styles.likeButton} type="button" onClick={handleLike}>
-        {isLiked ? <FaHeart color="red" /> : <FaRegHeart />}
+        {optimisticIsLiked ? <FaHeart color="red" /> : <FaRegHeart />}
       </button>
-      <span>{likeCount}</span>
+      <span>{optimisticLikeCount}</span>
     </div>
   );
 };


### PR DESCRIPTION
## 概要
ホームタイムラインなどで無限スクロールによって追加読み込みされた投稿に対し、「いいね」などのアクションを行うと、読み込んだ投稿全体が消えてしまうバグを修正しました。
加えて、アクションボタン（いいね・フォロー）クリック時に、UIが即座に反応しない問題を解消するため、楽観的更新（Optimistic UI）を導入し、ユーザー体験を向上させました。

## 実装したこと
- **無限スクロールのStateリセット防止 (`useInfiniteScroll.ts`)**:
  - `revalidatePath`による再レンダリング時に`useEffect`が走り、投稿リストのstateが初期化されてしまう問題を解決しました。
  - `useState`の初期化関数 `useState(() => initialPosts)` を用いることで、コンポーネントの初回マウント時のみ`initialPosts`がstateにセットされるように変更しました。

- **UIの即時反映（楽観的更新） (`LikeButton.tsx`)**:
  - ボタンコンポーネント内にローカルstate（`optimisticIsLiked`など）を導入しました。
  - ユーザーのアクション時に、まずローカルstateを更新してUIに即時反映させ、その後に非同期でサーバーへのリクエストを実行するよう変更しました。
  - サーバーへのリクエストが失敗した場合は、UIの状態をアクション前の状態にロールバックする処理を追加しました。
