### PR TITLE
feat(timeline): フォロー中のタイムライン機能を追加

### DIFF
--- a/src/features/posts/components/HomePageClient/HomePageClient.module.scss
+++ b/src/features/posts/components/HomePageClient/HomePageClient.module.scss
@@ -1,0 +1,49 @@
+@use 'styles/variables' as *;
+
+// ヘッダーエリア
+.header {
+  margin-bottom: 2rem;
+}
+
+// ページタイトル
+.title {
+  font-size: 1.8rem;
+  margin-bottom: 1.5rem;
+}
+
+// タブボタンのコンテナ
+.tabs {
+  display: flex;
+  border-bottom: 1px solid $color-gray-medium;
+}
+
+// 個別のタブボタン
+.tab {
+  margin-bottom: -1px;
+  padding: 0.75rem 1.5rem;
+  font-size: 1rem;
+  font-weight: bold;
+  color: $color-gray-dark;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  transition:
+    color 0.2s,
+    border-color 0.2s;
+
+  &:hover {
+    color: darken($color-gray-dark, 20%);
+  }
+}
+
+// アクティブなタブボタンのスタイル
+.tabActive {
+  color: $color-primary;
+  border-bottom-color: $color-primary;
+}
+
+// 投稿一覧が表示されるコンテンツエリア
+.content {
+  margin-top: 1.5rem;
+}

--- a/src/features/posts/components/HomePageClient/HomePageClient.tsx
+++ b/src/features/posts/components/HomePageClient/HomePageClient.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import { useState } from 'react';
+
+import { TimelineContextType } from '@/contexts/TimelineContext';
+import { InfiniteScrollTimeline } from '@/features/posts/components/InfiniteScrollTimeline/InfiniteScrollTimeline';
+import PostForm from '@/features/posts/components/PostForm/PostForm';
+import { PostWithProfile } from '@/types';
+
+import styles from './HomePageClient.module.scss';
+
+type HomePageClientProps = {
+  followingPosts: PostWithProfile[] | null;
+  allPosts: PostWithProfile[] | null;
+  timelineContextValue: TimelineContextType;
+};
+
+/**
+ * ホームページのUIと状態管理を担当するクライアントコンポーネント
+ * 「フォロー中」と「全ユーザー」のタブ切り替え機能を提供する
+ */
+export const HomePageClient = (props: HomePageClientProps) => {
+  const { followingPosts, allPosts, timelineContextValue } = props;
+  // 表示するタブ（'followingPosts' or 'allPosts'）の状態
+  const [activeTab, setActiveTab] = useState('followingPosts');
+
+  /**
+   * タブがアクティブかどうかに基づいて動的なクラス名を生成する
+   * @param tabName 'followingPosts' or 'allPosts'
+   * @returns {string} CSSクラス名の文字列
+   */
+  const getTabClassName = (tabName: string) => {
+    return `${styles.tab} ${activeTab === tabName ? styles.tabActive : ''}`;
+  };
+
+  return (
+    <>
+      <header className={styles.header}>
+        <h2 className={styles.title}>タイムライン</h2>
+        <PostForm />
+      </header>
+
+      <main>
+        <div className={styles.tabs}>
+          <button
+            type="button"
+            className={getTabClassName('followingPosts')}
+            onClick={() => {
+              setActiveTab('followingPosts');
+            }}
+          >
+            フォロー中
+          </button>
+          <button
+            type="button"
+            className={getTabClassName('allPosts')}
+            onClick={() => {
+              setActiveTab('allPosts');
+            }}
+          >
+            全ユーザー
+          </button>
+        </div>
+
+        <div className={styles.content}>
+          {/* PostList内部のコンポーネントがContextを必要とするため、ここで提供する */}
+          {activeTab === 'followingPosts' && (
+            <InfiniteScrollTimeline
+              initialPosts={followingPosts}
+              timelineContextValue={timelineContextValue}
+            />
+          )}
+          {activeTab === 'allPosts' && (
+            <InfiniteScrollTimeline
+              initialPosts={allPosts}
+              timelineContextValue={timelineContextValue}
+            />
+          )}
+        </div>
+      </main>
+    </>
+  );
+};


### PR DESCRIPTION
## 概要
ホームページに、フォロー中のユーザーの投稿のみを表示する専用のタイムラインを追加しました。
これにより、ユーザーは「全ユーザー」のタイムラインと「フォロー中」のタイムラインをタブで簡単に切り替えられるようになり、より関心の高いコンテンツに集中できるようになります。
この実装に伴い、ホームページのコンポーネント構成をリファクタリングし、サーバーコンポーネントとクライアントコンポーネントの責務を明確に分離しました。

## 実装したこと
- **フォロー中タイムライン用のデータ取得ロジック (`features/posts/actions.ts`)**:
  - `follows`テーブルからログインユーザーがフォローしているユーザーIDのリストを取得し、そのIDリストを元に`posts`テーブルを検索する、新しいサーバーアクション`fetchFollowingPosts`を追加しました。

- **タブ切り替えUIの実装 (`HomePageClient.tsx`)**:
  - 「フォロー中」「全ユーザー」のタブUIと、選択されたタブの状態を管理するクライアントコンポーネント`HomePageClient`を新規に作成しました。
  - `useState`を用いてアクティブなタブの状態を管理し、表示する投稿リストを動的に切り替えるロジックを実装しました。

- **ホームページのリファクタリング (`app/(main)/page.tsx`)**:
  - `page.tsx` (サーバーコンポーネント) の役割をデータ取得に専念させ、取得した「全投稿」と「フォロー中の投稿」の両データを`HomePageClient`にpropsとして渡すように変更しました。
  - これにより、サーバーサイドでのデータ準備とクライアントサイドでのUI操作の関心が明確に分離され、見通しの良いコンポーネント構成になりました。