### PR TITLE
refactor(timeline): useInfiniteScrollフックを汎用化

### DIFF
--- a/src/features/posts/components/HomePageClient/HomePageClient.tsx
+++ b/src/features/posts/components/HomePageClient/HomePageClient.tsx
@@ -1,4 +1,4 @@
-'use client'
+'use client';
 
 import { useState } from 'react';
 
@@ -8,6 +8,7 @@ import PostForm from '@/features/posts/components/PostForm/PostForm';
 import { PostWithProfile } from '@/types';
 
 import styles from './HomePageClient.module.scss';
+import { fetchFollowingPosts, fetchPosts } from '../../actions';
 
 type HomePageClientProps = {
   followingPosts: PostWithProfile[] | null;
@@ -68,12 +69,14 @@ export const HomePageClient = (props: HomePageClientProps) => {
             <InfiniteScrollTimeline
               initialPosts={followingPosts}
               timelineContextValue={timelineContextValue}
+              fetcher={fetchFollowingPosts}
             />
           )}
           {activeTab === 'allPosts' && (
             <InfiniteScrollTimeline
               initialPosts={allPosts}
               timelineContextValue={timelineContextValue}
+              fetcher={fetchPosts}
             />
           )}
         </div>

--- a/src/features/posts/components/InfiniteScrollTimeline/InfiniteScrollTimeline.tsx
+++ b/src/features/posts/components/InfiniteScrollTimeline/InfiniteScrollTimeline.tsx
@@ -6,9 +6,12 @@ import { type PostWithProfile } from '@/types';
 
 import PostList from '../PostList/PostList';
 
+type Fetcher = (page: number, pageSize: number) => Promise<PostWithProfile[]>;
+
 type InfiniteScrollTimelineProps = {
   initialPosts: PostWithProfile[] | null;
   timelineContextValue: TimelineContextType;
+  fetcher: Fetcher;
 };
 
 /**
@@ -17,8 +20,9 @@ type InfiniteScrollTimelineProps = {
 export const InfiniteScrollTimeline = ({
   initialPosts,
   timelineContextValue,
+  fetcher,
 }: InfiniteScrollTimelineProps) => {
-  const { posts, isLoading, ref } = useInfiniteScroll(initialPosts);
+  const { posts, isLoading, ref } = useInfiniteScroll(initialPosts, fetcher);
 
   return (
     <TimelineContext.Provider value={timelineContextValue}>

--- a/src/features/posts/hooks/useInfiniteScroll.ts
+++ b/src/features/posts/hooks/useInfiniteScroll.ts
@@ -5,14 +5,15 @@ import { useInView } from 'react-intersection-observer';
 
 import { PostWithProfile } from '@/types';
 
-import { fetchPosts } from '../actions';
+type Fetcher = (page: number, pageSize: number) => Promise<PostWithProfile[]>;
 
 /**
  * 投稿の無限スクロール機能を提供するカスタムフック
  * @param initialPosts - サーバーから最初に取得した投稿の配列
+ *  @param fetcher - 追加の投稿を読み込むための非同期関数
  * @returns 投稿リスト、ローディング状態、および監視対象に設定するref
  */
-export const useInfiniteScroll = (initialPosts: PostWithProfile[] | null) => {
+export const useInfiniteScroll = (initialPosts: PostWithProfile[] | null, fetcher: Fetcher) => {
   const PAGE_SIZE = 10;
 
   const [posts, setPosts] = useState(() => initialPosts ?? []);
@@ -29,7 +30,7 @@ export const useInfiniteScroll = (initialPosts: PostWithProfile[] | null) => {
       const loadMorePosts = async () => {
         setIsLoading(true);
         try {
-          const newPosts = await fetchPosts(page, PAGE_SIZE);
+          const newPosts = await fetcher(page, PAGE_SIZE);
 
           if (!newPosts.length) {
             setHasmore(false);
@@ -45,7 +46,7 @@ export const useInfiniteScroll = (initialPosts: PostWithProfile[] | null) => {
       };
       void loadMorePosts();
     }
-  }, [inView, isLoading, hasMore, page]);
+  }, [inView, isLoading, hasMore, page, fetcher]);
 
   return {
     posts,


### PR DESCRIPTION
## 概要
無限スクロールを実現している`useInfiniteScroll`フックを、より汎用的に再利用できるようリファクタリングしました。
以前の実装では、フック内部で「すべての投稿」を取得する`fetchPosts`関数が直接呼び出されていたため、「フォロー中」タイムラインでスクロールした際に意図しない投稿が読み込まれてしまう問題がありました。
今回の修正により、フックがデータ取得用の関数を引数として受け取れるようになり、単一のフックで複数の異なるタイムラインの無限スクロールを正しく処理できるようになりました。

## 実装したこと
- **`useInfiniteScroll`フックの汎用化 (`features/posts/hooks/useInfiniteScroll.ts`)**:
  - `fetchPosts`の直接呼び出しを廃止し、`fetcher`関数を引数として受け取るように変更しました。これにより、任意のデータ取得ロジックで無限スクロール機能を利用できるようになりました。

- **関連コンポーネントの修正 (`InfiniteScrollTimeline.tsx`, `HomePageClient.tsx`)**:
  - `useInfiniteScroll`フックの変更に伴い、`InfiniteScrollTimeline`コンポーネントが`fetcher`をpropsとして受け取れるように修正しました。
  - `HomePageClient`から、各タイムラインに対応する正しいデータ取得関数 (`fetchPosts`または`fetchFollowingPosts`) が渡されるように変更しました。