### PR TITLE
feat(timeline): フォロー中タイムラインに自身の投稿も表示

### DIFF
--- a/src/features/posts/actions.ts
+++ b/src/features/posts/actions.ts
@@ -156,6 +156,7 @@ export const fetchFollowingPosts = async (page: number, pageSize: number) => {
   }
 
   const followingList = follows.map((id) => id.following_id).filter((id) => id !== null);
+  followingList.push(user.id);
 
   if (!followingList.length) {
     return [];


### PR DESCRIPTION
## 概要
フォロー中のタイムラインに、フォローしているユーザーの投稿に加え、自分自身の投稿も表示されるようデータ取得のロジックを修正しました。

## 実装したこと
- **フォロー中タイムラインのデータ取得ロジックを修正 (`features/posts/actions.ts`)**:
  - `fetchFollowingPosts`関数内で、投稿を取得する際のユーザーIDリストに、ログイン中のユーザー自身のIDを追加しました。
