### PR TITLE
refactor: コンポーネントのmargin削除とgapへの移行、CSS変数を適用

### DIFF
--- a/src/components/ui/ClientFormattedTime/ClientFormattedTime.module.scss
+++ b/src/components/ui/ClientFormattedTime/ClientFormattedTime.module.scss
@@ -3,7 +3,6 @@
 .time {
   display: flex;
   justify-content: flex-end;
-  margin-top: 0.5rem;
   font-size: 0.8rem;
   color: $color-gray-medium;
   white-space: nowrap;

--- a/src/components/ui/ConfirmModal/ConfirmModal.module.scss
+++ b/src/components/ui/ConfirmModal/ConfirmModal.module.scss
@@ -23,5 +23,4 @@
   display: flex;
   justify-content: flex-end;
   gap: 1rem;
-  margin-top: 1rem;
 }

--- a/src/features/account/components/DeleteAccountForm/DeleteAccountForm.module.scss
+++ b/src/features/account/components/DeleteAccountForm/DeleteAccountForm.module.scss
@@ -23,7 +23,7 @@
 // 注意書き
 .notice {
   padding-left: 1.5rem;
-  color: crimson;
+  color: $color-error;
 }
 
 // 各フォーム項目のグループ
@@ -74,7 +74,6 @@
 // エラーメッセージ
 .errorMessage {
   color: $color-error;
-  margin-top: 0.25rem;
 }
 
 // 削除ボタンのコンテナ

--- a/src/features/posts/components/PostCard/PostCard.module.scss
+++ b/src/features/posts/components/PostCard/PostCard.module.scss
@@ -43,6 +43,13 @@
   line-height: 1.7;
 }
 
+// フッター
+.footer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
 // アクション部分のコンテナ
 .actions {
   margin-top: 0.75rem;

--- a/src/features/posts/components/PostCard/PostCard.tsx
+++ b/src/features/posts/components/PostCard/PostCard.tsx
@@ -43,7 +43,7 @@ const PostCard = ({ post }: PostCardProps) => {
           <p className={styles.content}>{post.content}</p>
         </main>
 
-        <footer>
+        <footer className={styles.footer}>
           <div className={styles.actions}>
             <LikeButton post={post} />
             {/* 投稿者本人のみ削除ボタンを表示 */}

--- a/src/features/posts/components/PostForm/PostForm.module.scss
+++ b/src/features/posts/components/PostForm/PostForm.module.scss
@@ -16,6 +16,9 @@
 
 // 投稿フォームのメインコンテナ
 .form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
   background-color: $color-white;
   padding: 1rem;
   border-radius: 8px;
@@ -24,8 +27,6 @@
 
 // メッセージ表示エリアのラッパー
 .messageWrapper {
-  margin-top: 0.5rem;
-  margin-bottom: 0.75rem;
   width: 100%;
 }
 
@@ -62,5 +63,4 @@
   justify-content: flex-end; // ボタンを右寄せ
   align-items: center;
   gap: 0.75rem; // ボタン間の余白
-  margin-top: 0.75rem;
 }


### PR DESCRIPTION
## 概要

コーディングガイドラインに基づき、CSSとコンポーネント設計をリファクタリングしました。
コンポーネント自体が持つ `margin` を排除し、代わりに親要素の `gap` プロパティでレイアウトを制御するよう変更しました。
これにより、コンポーネントの再利用性とレイアウトの予測可能性**を向上させています。

## 変更内容

- **`margin` の削除と `gap` への移行 (ガイドライン準拠)**
  - `ClientFormattedTime`, `ConfirmModal`, `PostForm` などのUIコンポーネントから `margin-top` を削除。
  - `PostCard`, `PostForm`, `DeleteAccountForm` などの親コンポーネント側で `gap` を指定し、子要素間の余白を一元管理するように修正しました。

- **CSS変数の適用**
  - `DeleteAccountForm` でハードコーディングされていた `crimson` (赤色) を、定義済みのCSS変数 (`$color-error`) に置き換え、デザインの一貫性を担保しました。