### PR TITLE
refactor: SearchBarのロジックをuseSearchBarカスタムフックに分離

### DIFF
--- a/src/features/search/components/SearchBar/SearchBar.tsx
+++ b/src/features/search/components/SearchBar/SearchBar.tsx
@@ -1,8 +1,7 @@
 'use client';
-
-import { useRouter } from 'next/navigation';
-import { useState } from 'react';
 import { FaSearch } from 'react-icons/fa';
+
+import { useSearchBar } from '@/features/search/hooks/useSearchBar';
 
 import styles from './SearchBar.module.scss';
 
@@ -10,21 +9,7 @@ import styles from './SearchBar.module.scss';
  * ヘッダーに表示される検索バーコンポーネント
  */
 export const SearchBar = () => {
-  const router = useRouter();
-  // ユーザーの入力を管理するstate
-  const [query, setQuery] = useState<string>('');
-
-  /**
-   * フォーム送信時の処理
-   * 入力されたキーワードをクエリパラメータとして、検索結果ページに遷移する
-   */
-  const handleSearch = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    if (!query) {
-      return;
-    }
-    router.push(`/search?q=${query}`);
-  };
+  const { query, handleSearch, onChange } = useSearchBar();
 
   return (
     <form className={styles.searchForm} onSubmit={handleSearch}>
@@ -33,9 +18,7 @@ export const SearchBar = () => {
         className={styles.searchInput}
         placeholder="投稿を検索..."
         value={query}
-        onChange={(e) => {
-          setQuery(e.target.value);
-        }}
+        onChange={onChange}
       />
       <button type="submit" className={styles.searchButton} aria-label="検索実行">
         <FaSearch size={16} />

--- a/src/features/search/hooks/useSearchBar.ts
+++ b/src/features/search/hooks/useSearchBar.ts
@@ -1,0 +1,31 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+export const useSearchBar = () => {
+  // ユーザーの入力を管理するstate
+  const [query, setQuery] = useState<string>('');
+
+  /**
+   * フォーム送信時の処理
+   * 入力されたキーワードをクエリパラメータとして、検索結果ページに遷移する
+   */
+  const router = useRouter();
+  const handleSearch = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!query) {
+      return;
+    }
+    router.push(`/search?q=${query}`);
+  };
+
+  /**
+   * inputの値が変更されたときにquery stateを更新する
+   */
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setQuery(e.target.value);
+  };
+
+  return { query, handleSearch, onChange };
+};


### PR DESCRIPTION
## 概要
`SearchBar` コンポーネントのリファクタリングを行いました。
ビューとロジックの関心の分離が目的です。

## 変更内容
- `SearchBar` 内の状態管理とイベントハンドラーを、新規に作成した `useSearchBar` カスタムフックに移動しました。