### PR TITLE
feat: 投稿作成APIの実装とフロントエンド連携

### DIFF
--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -1,26 +1,63 @@
+import { revalidatePath } from 'next/cache';
 import { NextResponse } from 'next/server';
-import { z } from 'zod';
 
-const createPostSchema = z.object({
-  content: z.string().min(1, { message: '本文を入力してください' }),
-});
+import { createPostSchema } from '@/lib/schema';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
 
+/**
+ * 新規投稿を作成するAPIエンドポイント
+ * 認証、語尾設定の取得、バリデーション、DB保存を行う
+ */
 export async function POST(request: Request) {
   try {
+    const supabase = await createSupabaseServerClient();
+
+    // ユーザー認証の確認
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json({ error: '認証されていません' }, { status: 401 });
+    }
+
+    // ユーザーの現在の語尾設定を取得
+    const { data: profileData, error: profileError } = await supabase
+      .from('profiles')
+      .select('current_gobi')
+      .eq('id', user.id)
+      .single();
+
+    if (profileError) {
+      return NextResponse.json({ error: 'ユーザー情報が見つかりません' }, { status: 500 });
+    }
+
+    const currentGobi = profileData.current_gobi ?? '';
+
+    // リクエストデータの取得
     const body = await request.json();
 
-    const result = createPostSchema.safeParse(body);
+    const result = createPostSchema(currentGobi).safeParse(body);
 
     if (!result.success) {
-      return NextResponse.json(
-        { error: 'バリデーションエラー', details: z.treeifyError(result.error) },
-        { status: 400 },
-      );
+      const errorMessage = result.error.issues[0].message;
+      return NextResponse.json({ error: errorMessage }, { status: 400 });
     }
 
     const { content } = result.data;
 
-    console.log('投稿データを受信しました:', content);
+    // データベースへの保存
+    const { error: insertError } = await supabase
+      .from('posts')
+      .insert({ content: content, user_id: user.id, gobi: currentGobi });
+
+    if (insertError) {
+      console.error('Insert Error:', insertError);
+      return NextResponse.json({ error: '投稿の保存に失敗しました' }, { status: 500 });
+    }
+
+    revalidatePath('/');
 
     return NextResponse.json(
       { message: '投稿が作成されました', post: { content } },

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+const createPostSchema = z.object({
+  content: z.string().min(1, { message: '本文を入力してください' }),
+});
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+
+    const result = createPostSchema.safeParse(body);
+
+    if (!result.success) {
+      return NextResponse.json(
+        { error: 'バリデーションエラー', details: z.treeifyError(result.error) },
+        { status: 400 },
+      );
+    }
+
+    const { content } = result.data;
+
+    console.log('投稿データを受信しました:', content);
+
+    return NextResponse.json(
+      { message: '投稿が作成されました', post: { content } },
+      { status: 201 },
+    );
+  } catch (error) {
+    console.error('API Error', error);
+    return NextResponse.json({ error: 'サーバー内部でエラーが発生しました' }, { status: 500 });
+  }
+}

--- a/src/features/posts/actions.ts
+++ b/src/features/posts/actions.ts
@@ -2,53 +2,7 @@
 
 import { revalidatePath } from 'next/cache';
 
-import { createPostSchema } from '@/lib/schema';
 import { getAuthenticatedClient } from '@/lib/utils';
-
-/**
- * 新規投稿作成
- * ユーザーのカスタム語尾が投稿内容に含まれているかチェック
- */
-export const createPost = async (formData: FormData) => {
-  const data = { content: formData.get('content') as string };
-
-  const { supabase, user } = await getAuthenticatedClient();
-
-  // ユーザーのプロフィールから現在の語尾を取得
-  const { data: profile, error: profileError } = await supabase
-    .from('profiles')
-    .select('current_gobi')
-    .eq('id', user.id)
-    .single();
-
-  if (profileError) {
-    throw new Error('プロフィールの取得に失敗しました。');
-  }
-
-  const gobi = profile.current_gobi;
-
-  // 語尾のバリデーション
-  if (!gobi) {
-    throw new Error('語尾が設定されていません');
-  }
-
-  const result = createPostSchema(gobi).safeParse(data);
-  if (!result.success) {
-    throw new Error('入力データが無効です。');
-  }
-
-  const { error: insertError } = await supabase
-    .from('posts')
-    .insert({ content: data.content, gobi: gobi, user_id: user.id });
-
-  if (insertError) {
-    console.error(insertError);
-    throw new Error('投稿の保存に失敗しました。');
-  }
-
-  // キャッシュを更新してホームページにリダイレクト
-  revalidatePath('/');
-};
 
 /**
  * 投稿削除

--- a/src/features/posts/hooks/usePostForm.ts
+++ b/src/features/posts/hooks/usePostForm.ts
@@ -1,46 +1,63 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useRouter } from 'next/navigation';
-import { SubmitHandler, useForm } from 'react-hook-form';
-import { toast } from 'react-hot-toast';
+import { useState } from 'react';
+import { useForm, type SubmitHandler } from 'react-hook-form';
+import toast from 'react-hot-toast';
+import { z } from 'zod';
 
-import { useProfileData } from '@/features/profile/hooks/useProfileData';
-import { createPostSchema } from '@/lib/schema';
+import { CreatePostRequest } from '@/types';
 
-import { createPost } from '../actions';
+const createPostSchema = z.object({
+  content: z.string().min(1, { message: '本文を入力してください' }),
+});
 
-type PostFormData = {
-  content: string;
-};
+type CreatePostInput = z.infer<typeof createPostSchema>;
 
-/**
- * 投稿フォームに関するロジックをすべてカプセル化したカスタムフック
- */
 export const usePostForm = () => {
   const router = useRouter();
-  const { gobi, isProfileComplete, isLoading } = useProfileData();
-  const postSchema = createPostSchema(gobi ?? '');
 
-  const form = useForm<PostFormData>({
-    resolver: zodResolver(postSchema),
-    mode: 'onBlur',
+  const [isProfileComplete] = useState(true);
+  const [isLoading] = useState(false);
+
+  const form = useForm<CreatePostInput>({
+    resolver: zodResolver(createPostSchema),
     defaultValues: {
       content: '',
     },
   });
 
-  const onSubmit: SubmitHandler<PostFormData> = async (data) => {
-    const formData = new FormData();
-    formData.append('content', data.content);
-
+  const onSubmit: SubmitHandler<CreatePostInput> = async (data) => {
     try {
-      await createPost(formData);
+      const requestBody: CreatePostRequest = {
+        content: data.content,
+      };
+
+      const res = await fetch('/api/posts', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(requestBody),
+      });
+
+      if (!res.ok) {
+        const errorData = (await res.json()) as { error?: string };
+        throw new Error(errorData.error ?? '投稿に失敗しました');
+      }
+
+      toast.success('投稿しました！');
       form.reset();
       router.refresh();
     } catch (error) {
-      console.error('投稿エラー:', error);
-      toast.error('投稿に失敗しました。時間をおいて再実行してください。');
+      console.error(error);
+      toast.error('エラーが発生しました');
     }
   };
 
-  return { form, onSubmit, isProfileComplete, isLoading };
+  return {
+    form,
+    onSubmit,
+    isProfileComplete,
+    isLoading,
+  };
 };

--- a/src/features/posts/hooks/usePostForm.ts
+++ b/src/features/posts/hooks/usePostForm.ts
@@ -1,23 +1,27 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
 import { useForm, type SubmitHandler } from 'react-hook-form';
 import toast from 'react-hot-toast';
 import { z } from 'zod';
 
+import { useProfileData } from '@/features/profile/hooks/useProfileData';
 import { CreatePostRequest } from '@/types';
 
+// クライアント側での最低限の入力チェック用スキーマ
 const createPostSchema = z.object({
   content: z.string().min(1, { message: '本文を入力してください' }),
 });
 
 type CreatePostInput = z.infer<typeof createPostSchema>;
 
+/**
+ * 投稿フォームのロジックを管理するカスタムフック
+ * APIとの通信、エラーハンドリング、フォームの状態管理を行う
+ */
 export const usePostForm = () => {
   const router = useRouter();
 
-  const [isProfileComplete] = useState(true);
-  const [isLoading] = useState(false);
+  const { isProfileComplete, isLoading } = useProfileData();
 
   const form = useForm<CreatePostInput>({
     resolver: zodResolver(createPostSchema),
@@ -32,6 +36,7 @@ export const usePostForm = () => {
         content: data.content,
       };
 
+      // APIルートへリクエスト送信
       const res = await fetch('/api/posts', {
         method: 'POST',
         headers: {
@@ -50,7 +55,12 @@ export const usePostForm = () => {
       router.refresh();
     } catch (error) {
       console.error(error);
-      toast.error('エラーが発生しました');
+
+      if (error instanceof Error) {
+        toast.error(error.message);
+      } else {
+        toast.error('エラーが発生しました');
+      }
     }
   };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,3 +7,7 @@ export type PostWithProfile = Post & {
   profiles: Pick<Profile, 'user_name' | 'avatar_url'> | null;
   likes: Array<{ count: number }>;
 };
+
+export type CreatePostRequest = {
+  content: string;
+};


### PR DESCRIPTION
## 概要
新規投稿作成機能をNext.jsのAPI Routeを使用して実装し、フロントエンドのフォームと連携させました。
また、データ保存処理の移行に伴い、不要となったServer Actionsを削除しました。

## 変更内容

- **API Routeの新規作成 (`src/app/api/posts/route.ts`)**
  - POSTリクエストを受け付けるエンドポイントの実装
  - データベースへの保存処理の実装
  - 具体的なエラーメッセージを含むJSONレスポンスの返却

- **投稿フォーム用フックの改修 (`src/features/posts/hooks/usePostForm.ts`)**
  - Server Actionsの呼び出しから、`/api/posts`へのfetchリクエストへ処理を変更
  - APIから返却されたエラーメッセージを取得し、Toastで表示するエラーハンドリングの実装

- **既存Server Actionsの整理 (`src/features/posts/actions.ts`)**
  - API Routeへの移行に伴い、不要となった`createPost`関数を削除